### PR TITLE
fix regression when forwarding sent sms

### DIFF
--- a/application/controllers/Messages.php
+++ b/application/controllers/Messages.php
@@ -105,7 +105,7 @@ class Messages extends MY_Controller {
 					$multipart['option'] = 'check';
 					$multipart['id_message'] = $id;
 					$tmp_check = $this->Message_model->get_multipart($multipart);
-					if ($tmp_check === TRUE)
+					if ($tmp_check > 0)
 					{
 						$multipart['option'] = 'all';
 						foreach ($this->Message_model->get_multipart($multipart)->result() as $part)


### PR DESCRIPTION
When forwarding multipart SMS that is in sentitems, only the first part was of the SMS was
forwarded. This was a regression in 0a0b9aad385b96edde2670f889af1b5a252acc6b.
Now fixed