### PR TITLE
restore missing '+' at the beginning of phone nb

### DIFF
--- a/application/controllers/Phonebook.php
+++ b/application/controllers/Phonebook.php
@@ -390,7 +390,7 @@ class Phonebook extends MY_Controller {
 			// Add identifier, c for contact, g for group, u for user
 			foreach ($query as $key => $val)
 			{
-				$query[$key]['name'] .= ' ('.str_replace('+', '', $val['id']).')';
+				$query[$key]['name'] .= ' ('.$val['id'].')';
 				$query[$key]['id'] = $val['id'].':c';
 			}
 			$group = $this->Phonebook_model->search_group($param)->result_array();


### PR DESCRIPTION
When on compose dialog & searching for contact, the results didn't show the + sign
at the beginning of the number