### PR TITLE
fix validation check on person in compose dialog

### DIFF
--- a/application/language/czech/kalkun_lang.php
+++ b/application/language/czech/kalkun_lang.php
@@ -392,3 +392,6 @@ $lang['Open shortcut help'] = 'Open shortcut help';
 $lang['Error'] = 'Error';
 $lang['Please specify a valid mobile phone number'] = 'Please specify a valid mobile phone number';
 $lang['Go to {0}'] = 'Go to {0}';
+$lang['No results'] = 'No results';
+$lang['Please enter a name for your message. This should be unique.'] = 'Please enter a name for your message. This should be unique.';
+$lang['Are you sure? This will overwrite previous message.'] = 'Are you sure? This will overwrite previous message.';

--- a/application/language/danish/kalkun_lang.php
+++ b/application/language/danish/kalkun_lang.php
@@ -392,3 +392,6 @@ $lang['Open shortcut help'] = 'Open shortcut help';
 $lang['Error'] = 'Error';
 $lang['Please specify a valid mobile phone number'] = 'Please specify a valid mobile phone number';
 $lang['Go to {0}'] = 'Go to {0}';
+$lang['No results'] = 'No results';
+$lang['Please enter a name for your message. This should be unique.'] = 'Please enter a name for your message. This should be unique.';
+$lang['Are you sure? This will overwrite previous message.'] = 'Are you sure? This will overwrite previous message.';

--- a/application/language/dutch/kalkun_lang.php
+++ b/application/language/dutch/kalkun_lang.php
@@ -392,3 +392,6 @@ $lang['Open shortcut help'] = 'Open shortcut help';
 $lang['Error'] = 'Error';
 $lang['Please specify a valid mobile phone number'] = 'Please specify a valid mobile phone number';
 $lang['Go to {0}'] = 'Go to {0}';
+$lang['No results'] = 'No results';
+$lang['Please enter a name for your message. This should be unique.'] = 'Please enter a name for your message. This should be unique.';
+$lang['Are you sure? This will overwrite previous message.'] = 'Are you sure? This will overwrite previous message.';

--- a/application/language/english/kalkun_lang.php
+++ b/application/language/english/kalkun_lang.php
@@ -393,3 +393,6 @@ $lang['Open shortcut help'] = 'Open shortcut help';
 $lang['Error'] = 'Error';
 $lang['Please specify a valid mobile phone number'] = 'Please specify a valid mobile phone number';
 $lang['Go to {0}'] = 'Go to {0}';
+$lang['No results'] = 'No results';
+$lang['Please enter a name for your message. This should be unique.'] = 'Please enter a name for your message. This should be unique.';
+$lang['Are you sure? This will overwrite previous message.'] = 'Are you sure? This will overwrite previous message.';

--- a/application/language/finnish/kalkun_lang.php
+++ b/application/language/finnish/kalkun_lang.php
@@ -392,3 +392,6 @@ $lang['Open shortcut help'] = 'Open shortcut help';
 $lang['Error'] = 'Error';
 $lang['Please specify a valid mobile phone number'] = 'Please specify a valid mobile phone number';
 $lang['Go to {0}'] = 'Go to {0}';
+$lang['No results'] = 'No results';
+$lang['Please enter a name for your message. This should be unique.'] = 'Please enter a name for your message. This should be unique.';
+$lang['Are you sure? This will overwrite previous message.'] = 'Are you sure? This will overwrite previous message.';

--- a/application/language/french/kalkun_lang.php
+++ b/application/language/french/kalkun_lang.php
@@ -392,3 +392,6 @@ $lang['Open shortcut help'] = 'Open shortcut help';
 $lang['Error'] = 'Error';
 $lang['Please specify a valid mobile phone number'] = 'Please specify a valid mobile phone number';
 $lang['Go to {0}'] = 'Go to {0}';
+$lang['No results'] = 'No results';
+$lang['Please enter a name for your message. This should be unique.'] = 'Please enter a name for your message. This should be unique.';
+$lang['Are you sure? This will overwrite previous message.'] = 'Are you sure? This will overwrite previous message.';

--- a/application/language/german/kalkun_lang.php
+++ b/application/language/german/kalkun_lang.php
@@ -392,3 +392,6 @@ $lang['Open shortcut help'] = 'Open shortcut help';
 $lang['Error'] = 'Error';
 $lang['Please specify a valid mobile phone number'] = 'Please specify a valid mobile phone number';
 $lang['Go to {0}'] = 'Go to {0}';
+$lang['No results'] = 'No results';
+$lang['Please enter a name for your message. This should be unique.'] = 'Please enter a name for your message. This should be unique.';
+$lang['Are you sure? This will overwrite previous message.'] = 'Are you sure? This will overwrite previous message.';

--- a/application/language/hungarian/kalkun_lang.php
+++ b/application/language/hungarian/kalkun_lang.php
@@ -392,3 +392,6 @@ $lang['Open shortcut help'] = 'Open shortcut help';
 $lang['Error'] = 'Error';
 $lang['Please specify a valid mobile phone number'] = 'Please specify a valid mobile phone number';
 $lang['Go to {0}'] = 'Go to {0}';
+$lang['No results'] = 'No results';
+$lang['Please enter a name for your message. This should be unique.'] = 'Please enter a name for your message. This should be unique.';
+$lang['Are you sure? This will overwrite previous message.'] = 'Are you sure? This will overwrite previous message.';

--- a/application/language/indonesian/kalkun_lang.php
+++ b/application/language/indonesian/kalkun_lang.php
@@ -392,3 +392,6 @@ $lang['Open shortcut help'] = 'Open shortcut help';
 $lang['Error'] = 'Error';
 $lang['Please specify a valid mobile phone number'] = 'Please specify a valid mobile phone number';
 $lang['Go to {0}'] = 'Go to {0}';
+$lang['No results'] = 'No results';
+$lang['Please enter a name for your message. This should be unique.'] = 'Please enter a name for your message. This should be unique.';
+$lang['Are you sure? This will overwrite previous message.'] = 'Are you sure? This will overwrite previous message.';

--- a/application/language/italian/kalkun_lang.php
+++ b/application/language/italian/kalkun_lang.php
@@ -392,3 +392,6 @@ $lang['Open shortcut help'] = 'Open shortcut help';
 $lang['Error'] = 'Error';
 $lang['Please specify a valid mobile phone number'] = 'Please specify a valid mobile phone number';
 $lang['Go to {0}'] = 'Go to {0}';
+$lang['No results'] = 'No results';
+$lang['Please enter a name for your message. This should be unique.'] = 'Please enter a name for your message. This should be unique.';
+$lang['Are you sure? This will overwrite previous message.'] = 'Are you sure? This will overwrite previous message.';

--- a/application/language/polish/kalkun_lang.php
+++ b/application/language/polish/kalkun_lang.php
@@ -392,3 +392,6 @@ $lang['Open shortcut help'] = 'Open shortcut help';
 $lang['Error'] = 'Error';
 $lang['Please specify a valid mobile phone number'] = 'Please specify a valid mobile phone number';
 $lang['Go to {0}'] = 'Go to {0}';
+$lang['No results'] = 'No results';
+$lang['Please enter a name for your message. This should be unique.'] = 'Please enter a name for your message. This should be unique.';
+$lang['Are you sure? This will overwrite previous message.'] = 'Are you sure? This will overwrite previous message.';

--- a/application/language/portuguese-brazilian/kalkun_lang.php
+++ b/application/language/portuguese-brazilian/kalkun_lang.php
@@ -392,3 +392,6 @@ $lang['Open shortcut help'] = 'Open shortcut help';
 $lang['Error'] = 'Error';
 $lang['Please specify a valid mobile phone number'] = 'Please specify a valid mobile phone number';
 $lang['Go to {0}'] = 'Go to {0}';
+$lang['No results'] = 'No results';
+$lang['Please enter a name for your message. This should be unique.'] = 'Please enter a name for your message. This should be unique.';
+$lang['Are you sure? This will overwrite previous message.'] = 'Are you sure? This will overwrite previous message.';

--- a/application/language/portuguese/kalkun_lang.php
+++ b/application/language/portuguese/kalkun_lang.php
@@ -392,3 +392,6 @@ $lang['Open shortcut help'] = 'Open shortcut help';
 $lang['Error'] = 'Error';
 $lang['Please specify a valid mobile phone number'] = 'Please specify a valid mobile phone number';
 $lang['Go to {0}'] = 'Go to {0}';
+$lang['No results'] = 'No results';
+$lang['Please enter a name for your message. This should be unique.'] = 'Please enter a name for your message. This should be unique.';
+$lang['Are you sure? This will overwrite previous message.'] = 'Are you sure? This will overwrite previous message.';

--- a/application/language/russian/kalkun_lang.php
+++ b/application/language/russian/kalkun_lang.php
@@ -392,3 +392,6 @@ $lang['Open shortcut help'] = 'Open shortcut help';
 $lang['Error'] = 'Error';
 $lang['Please specify a valid mobile phone number'] = 'Please specify a valid mobile phone number';
 $lang['Go to {0}'] = 'Go to {0}';
+$lang['No results'] = 'No results';
+$lang['Please enter a name for your message. This should be unique.'] = 'Please enter a name for your message. This should be unique.';
+$lang['Are you sure? This will overwrite previous message.'] = 'Are you sure? This will overwrite previous message.';

--- a/application/language/slovak/kalkun_lang.php
+++ b/application/language/slovak/kalkun_lang.php
@@ -392,3 +392,6 @@ $lang['Open shortcut help'] = 'Open shortcut help';
 $lang['Error'] = 'Error';
 $lang['Please specify a valid mobile phone number'] = 'Please specify a valid mobile phone number';
 $lang['Go to {0}'] = 'Go to {0}';
+$lang['No results'] = 'No results';
+$lang['Please enter a name for your message. This should be unique.'] = 'Please enter a name for your message. This should be unique.';
+$lang['Are you sure? This will overwrite previous message.'] = 'Are you sure? This will overwrite previous message.';

--- a/application/language/spanish/kalkun_lang.php
+++ b/application/language/spanish/kalkun_lang.php
@@ -392,3 +392,6 @@ $lang['Open shortcut help'] = 'Open shortcut help';
 $lang['Error'] = 'Error';
 $lang['Please specify a valid mobile phone number'] = 'Please specify a valid mobile phone number';
 $lang['Go to {0}'] = 'Go to {0}';
+$lang['No results'] = 'No results';
+$lang['Please enter a name for your message. This should be unique.'] = 'Please enter a name for your message. This should be unique.';
+$lang['Are you sure? This will overwrite previous message.'] = 'Are you sure? This will overwrite previous message.';

--- a/application/language/turkish/kalkun_lang.php
+++ b/application/language/turkish/kalkun_lang.php
@@ -392,3 +392,6 @@ $lang['Open shortcut help'] = 'Open shortcut help';
 $lang['Error'] = 'Error';
 $lang['Please specify a valid mobile phone number'] = 'Please specify a valid mobile phone number';
 $lang['Go to {0}'] = 'Go to {0}';
+$lang['No results'] = 'No results';
+$lang['Please enter a name for your message. This should be unique.'] = 'Please enter a name for your message. This should be unique.';
+$lang['Are you sure? This will overwrite previous message.'] = 'Are you sure? This will overwrite previous message.';

--- a/application/views/js_init/message/js_compose.php
+++ b/application/views/js_init/message/js_compose.php
@@ -66,6 +66,7 @@
 
 		// validation
 		$("#composeForm").validate({
+			ignore: '', // By default, jquery validation ignores hidden fields. Set this to the empty string to not ignore hidden fields (needed for personvalue which is hidden by tokenInput.
 			rules: {
 				personvalue: {
 					required: "#sendoption1:checked",

--- a/application/views/js_init/message/js_compose.php
+++ b/application/views/js_init/message/js_compose.php
@@ -20,7 +20,7 @@
 
 		$("#personvalue").tokenInput("<?php echo site_url('phonebook/get_phonebook/').'/'.(isset($source) ? $source : '');?>", {
 			hintText: "<?php echo tr('Insert name from contact list')?>",
-			noResultsText: "No results",
+			noResultsText: "<?php echo tr('No results'); ?>",
 			searchingText: "<?php echo tr('Searching...'); ?>",
 			preventDuplicates: true,
 			method: "POST",
@@ -109,7 +109,7 @@
 		});
 
 		/*
-		var url = "<?php echo  site_url();?>/messages/get_phonebook";
+		var url = "<?php echo site_url();?>/messages/get_phonebook";
 		$("#input_box").tokenInput(url, {
 			hintText: "Type in the names of your phonebook",
 			noResultsText: "No results",
@@ -118,7 +118,7 @@
 		*/
 
 		// Phonebook autocompleter
-		/*var url = "<?php echo  site_url();?>/messages/get_phonebook";
+		/*var url = "<?php echo site_url();?>/messages/get_phonebook";
 		$("#input_box").autocomplete(url, {
 			multiple: true,
 			multipleSeparator: ", \n",
@@ -253,13 +253,13 @@
 
 	function save_canned_response(name) {
 
-		if (name == null) var name = prompt("Please enter a Name for Your Message. This should be unique.", '', "Message Name");
+		if (name == null) var name = prompt("<?php echo tr('Please enter a name for your message. This should be unique.'); ?>", '', "Message Name");
 		else {
-			var c = confirm("Are you Sure?  This will overwrite previous message");
+			var c = confirm("<?php echo tr('Are you sure? This will overwrite previous message.'); ?>");
 			if (!c) return;
 		}
 
-		var dest_url = "<?php echo  site_url();?>/messages/canned_response/save";
+		var dest_url = "<?php echo site_url();?>/messages/canned_response/save";
 
 		if (name != null) {
 			$('.loading_area').html("<?php echo tr('Saving...');?>");
@@ -276,7 +276,7 @@
 
 	function insert_canned_response(name) {
 
-		var dest_url = "<?php echo  site_url();?>/messages/canned_response/get";
+		var dest_url = "<?php echo site_url();?>/messages/canned_response/get";
 		$.post(dest_url, {
 			'name': name
 		}, function(data) {
@@ -287,9 +287,9 @@
 
 	function delete_canned_response(name) {
 
-		var c = confirm("Are you Sure?");
+		var c = confirm("<?php echo tr('Are you sure?'); ?>");
 		if (!c) return;
-		var dest_url = "<?php echo  site_url();?>/messages/canned_response/delete";
+		var dest_url = "<?php echo site_url();?>/messages/canned_response/delete";
 		$.post(dest_url, {
 			'name': name
 		}, function() {
@@ -298,7 +298,7 @@
 	}
 
 	function update_canned_responses() {
-		var dest_url = "<?php echo  site_url();?>/messages/canned_response/list";
+		var dest_url = "<?php echo site_url();?>/messages/canned_response/list";
 		$.get(dest_url, function(data) {
 			$("#canned_response_container").html(data)
 		});

--- a/application/views/main/messages/compose.php
+++ b/application/views/main/messages/compose.php
@@ -120,7 +120,7 @@ else
 		<td>&nbsp;</td>
 		<td>
 			<div id="person">
-				<textarea id="personvalue" style="width: 95%;" name="personvalue" ></textarea>
+				<textarea id="personvalue" style="width: 95%;" name="personvalue"></textarea>
 			</div>
 
 			<div id="manually" class="hidden">

--- a/application/views/main/messages/compose.php
+++ b/application/views/main/messages/compose.php
@@ -120,7 +120,7 @@ else
 		<td>&nbsp;</td>
 		<td>
 			<div id="person">
-				<textarea id="personvalue" style="width: 95%;" name="personvalue" /></textarea>
+				<textarea id="personvalue" style="width: 95%;" name="personvalue" ></textarea>
 			</div>
 
 			<div id="manually" class="hidden">


### PR DESCRIPTION
When composing a SMS and choosing a recepient by phonebook, the validation of the field didn't work.
This was because jquery validation plugin doesn't validate hidden fields by default.
The field is actually hidden by tokenInput, so we need to tell jquery not to ignore hidden fields