### PR TITLE
remove width constraint in some css elements

### DIFF
--- a/media/css/base.css
+++ b/media/css/base.css
@@ -188,11 +188,11 @@ textarea {
 .left_column,
 .left_column_big {
 	float: left;
-	width: 325px;
+	/*width: 325px;*/
 }
 
 .left_column_big {
-	width: 425px;
+	/*width: 425px;*/
 }
 
 #right_column,
@@ -938,7 +938,7 @@ label.error {
 
 #window_title_left {
 	float: left;
-	width: 150px;
+	/*width: 150px;*/
 }
 
 #window_title_right {


### PR DESCRIPTION
In Users & Phonebook views, with some languages, the set width created display
and alignement problems of the buttons. Remove the width constraint to let the
browser adapt the width at best