### PR TITLE
rename plugin_model to single name

### DIFF
--- a/application/controllers/Daemon.php
+++ b/application/controllers/Daemon.php
@@ -223,9 +223,9 @@ class Daemon extends CI_Controller {
 	function server_alert_daemon()
 	{
 		$this->load->model(array('Kalkun_model', 'Message_model'));
-		$this->load->model('server_alert/server_alert_model', 'plugin_model');
+		$this->load->model('server_alert/server_alert_model', 'server_alert_model');
 
-		$tmp_data = $this->plugin_model->get('active');
+		$tmp_data = $this->server_alert_model->get('active');
 		foreach ($tmp_data->result() as $tmp)
 		{
 			$fp = fsockopen($tmp->ip_address, $tmp->port_number, $errno, $errstr, 60);
@@ -238,7 +238,7 @@ class Daemon extends CI_Controller {
 				$data['class'] = '1';
 				$data['uid'] = '1';
 				$this->Message_model->send_messages($data);
-				$this->plugin_model->change_state($tmp->id_server_alert, 'false');
+				$this->server_alert_model->change_state($tmp->id_server_alert, 'false');
 			}
 		}
 	}

--- a/application/plugins/Plugin_controller.php
+++ b/application/plugins/Plugin_controller.php
@@ -93,7 +93,7 @@ class Plugin_controller extends MY_Controller {
 		// if models exist
 		if (file_exists(APPPATH.'models/plugin/'.$this->plugin_name.'_model.php'))
 		{
-			$this->load->model('plugin/'.$this->plugin_name.'_model', 'plugin_model');
+			$this->load->model('plugin/'.$this->plugin_name.'_model', $this->plugin_name.'_model');
 		}
 	}
 }

--- a/application/plugins/blacklist_number/blacklist_number.php
+++ b/application/plugins/blacklist_number/blacklist_number.php
@@ -65,11 +65,11 @@ function blacklist_number_install()
 function blacklist_number_incoming($sms)
 {
 	$CI = &get_instance();
-	$CI->load->model('blacklist_number/blacklist_number_model', 'plugin_model');
+	$CI->load->model('blacklist_number/blacklist_number_model', 'blacklist_number_model');
 	$evil = array();
 
 	// Get blacklist number
-	$lists = $CI->plugin_model->get('all')->result_array();
+	$lists = $CI->blacklist_number_model->get('all')->result_array();
 	foreach ($lists as $tmp)
 	{
 		$evil[] = $tmp['phone_number'];
@@ -86,11 +86,11 @@ function blacklist_number_incoming($sms)
 function blacklist_number_outgoing($numbers = array())
 {
 	$CI = &get_instance();
-	$CI->load->model('blacklist_number/blacklist_number_model', 'plugin_model');
+	$CI->load->model('blacklist_number/blacklist_number_model', 'blacklist_number_model');
 	$evil = array();
 
 	// Get blacklist number
-	$lists = $CI->plugin_model->get('all')->result_array();
+	$lists = $CI->blacklist_number_model->get('all')->result_array();
 	foreach ($lists as $tmp)
 	{
 		$evil[] = $tmp['phone_number'];

--- a/application/plugins/blacklist_number/controllers/Blacklist_number.php
+++ b/application/plugins/blacklist_number/controllers/Blacklist_number.php
@@ -26,7 +26,7 @@ class Blacklist_number extends Plugin_controller {
 	{
 		parent::__construct();
 		$this->load->model('Kalkun_model');
-		$this->load->model('blacklist_number_model', 'plugin_model');
+		$this->load->model('blacklist_number_model');
 		$this->load->helper('kalkun');
 	}
 
@@ -36,18 +36,18 @@ class Blacklist_number extends Plugin_controller {
 		{
 			if ($this->input->post('editid_blacklist_number'))
 			{
-				$this->plugin_model->update();
+				$this->blacklist_number_model->update();
 			}
 			else
 			{
-				$this->plugin_model->add();
+				$this->blacklist_number_model->add();
 			}
 			redirect('plugin/blacklist_number');
 		}
 
 		$this->load->library('pagination');
 		$config['base_url'] = site_url('plugin/blacklist_number/index');
-		$config['total_rows'] = $this->plugin_model->get('count');
+		$config['total_rows'] = $this->blacklist_number_model->get('count');
 		$config['per_page'] = $this->Kalkun_model->get_setting()->row('paging');
 		$config['cur_tag_open'] = '<span id="current">';
 		$config['cur_tag_close'] = '</span>';
@@ -55,14 +55,14 @@ class Blacklist_number extends Plugin_controller {
 		$this->pagination->initialize($config);
 
 		$data['main'] = 'index';
-		$data['blacklist'] = $this->plugin_model->get('paginate', $config['per_page'], $this->uri->segment(4, 0));
+		$data['blacklist'] = $this->blacklist_number_model->get('paginate', $config['per_page'], $this->uri->segment(4, 0));
 		$data['number'] = $this->uri->segment(4, 0) + 1;
 		$this->load->view('main/layout', $data);
 	}
 
 	function delete($id)
 	{
-		$this->plugin_model->delete($id);
+		$this->blacklist_number_model->delete($id);
 		redirect('plugin/blacklist_number');
 	}
 }

--- a/application/plugins/server_alert/controllers/Server_alert.php
+++ b/application/plugins/server_alert/controllers/Server_alert.php
@@ -26,7 +26,7 @@ class Server_alert extends Plugin_controller {
 	{
 		parent::__construct();
 		$this->load->model('Kalkun_model');
-		$this->load->model('server_alert_model', 'plugin_model');
+		$this->load->model('server_alert_model');
 		$this->load->helper('kalkun');
 	}
 
@@ -36,18 +36,18 @@ class Server_alert extends Plugin_controller {
 		{
 			if ($this->input->post('editid_server_alert'))
 			{
-				$this->plugin_model->update();
+				$this->server_alert_model->update();
 			}
 			else
 			{
-				$this->plugin_model->add();
+				$this->server_alert_model->add();
 			}
 			redirect('plugin/server_alert');
 		}
 
 		$this->load->library('pagination');
 		$config['base_url'] = site_url('plugin/server_alert/index');
-		$config['total_rows'] = $this->plugin_model->get('count');
+		$config['total_rows'] = $this->server_alert_model->get('count');
 		$config['per_page'] = $this->Kalkun_model->get_setting()->row('paging');
 		$config['cur_tag_open'] = '<span id="current">';
 		$config['cur_tag_close'] = '</span>';
@@ -55,27 +55,27 @@ class Server_alert extends Plugin_controller {
 		$this->pagination->initialize($config);
 
 		$data['main'] = 'index';
-		$data['alert'] = $this->plugin_model->get('paginate', $config['per_page'], $this->uri->segment(4, 0));
+		$data['alert'] = $this->server_alert_model->get('paginate', $config['per_page'], $this->uri->segment(4, 0));
 		$data['number'] = $this->uri->segment(4, 0) + 1;
 
-		$data['time_interval'] = $this->plugin_model->get_time_interval();
+		$data['time_interval'] = $this->server_alert_model->get_time_interval();
 		$this->load->view('main/layout', $data);
 	}
 
 	function delete($id)
 	{
-		$this->plugin_model->delete($id);
+		$this->server_alert_model->delete($id);
 		redirect('plugin/server_alert');
 	}
 
 	function change_state($id)
 	{
-		$this->plugin_model->change_state($id, 'true');
+		$this->server_alert_model->change_state($id, 'true');
 		redirect('plugin/server_alert');
 	}
 
 	function get_time_interval()
 	{
-		echo 'Total Time Interval : '.$this->plugin_model->get_time_interval().' seconds';
+		echo 'Total Time Interval : '.$this->server_alert_model->get_time_interval().' seconds';
 	}
 }

--- a/application/plugins/sms_credit/controllers/Sms_credit.php
+++ b/application/plugins/sms_credit/controllers/Sms_credit.php
@@ -30,7 +30,7 @@ class Sms_credit extends Plugin_controller {
 	function __construct()
 	{
 		parent::__construct();
-		$this->load->model('sms_credit_model', 'plugin_model');
+		$this->load->model('sms_credit_model');
 	}
 
 	// --------------------------------------------------------------------
@@ -53,7 +53,7 @@ class Sms_credit extends Plugin_controller {
 
 		$this->load->library('pagination');
 		$config['base_url'] = site_url('plugin/sms_credit/index');
-		$config['total_rows'] = $this->plugin_model->get_users()->num_rows();
+		$config['total_rows'] = $this->sms_credit_model->get_users()->num_rows();
 		$config['per_page'] = $this->Kalkun_model->get_setting()->row('paging');
 		$config['cur_tag_open'] = '<span id="current">';
 		$config['cur_tag_close'] = '</span>';
@@ -64,8 +64,8 @@ class Sms_credit extends Plugin_controller {
 
 		$data['main'] = 'index';
 		$data['title'] = 'Users Credit';
-		$data['users'] = $this->plugin_model->get_users($param);
-		$data['packages'] = $this->plugin_model->get_packages();
+		$data['users'] = $this->sms_credit_model->get_users($param);
+		$data['packages'] = $this->sms_credit_model->get_packages();
 
 		$this->load->view('main/layout', $data);
 	}
@@ -86,12 +86,12 @@ class Sms_credit extends Plugin_controller {
 			if (empty($this->input->post('id_user')))
 			{
 				// add user
-				$this->plugin_model->add_users();
+				$this->sms_credit_model->add_users();
 			}
 			else
 			{
 				// edit user
-				$this->plugin_model->change_users_package();
+				$this->sms_credit_model->change_users_package();
 			}
 
 			redirect('plugin/sms_credit');
@@ -109,7 +109,7 @@ class Sms_credit extends Plugin_controller {
 	 */
 	function delete_users($id = NULL)
 	{
-		$this->plugin_model->delete_users($id);
+		$this->sms_credit_model->delete_users($id);
 		redirect('plugin/sms_credit');
 	}
 
@@ -126,7 +126,7 @@ class Sms_credit extends Plugin_controller {
 	{
 		$this->load->library('pagination');
 		$config['base_url'] = site_url('plugin/sms_credit/packages');
-		$config['total_rows'] = $this->plugin_model->get_packages()->num_rows();
+		$config['total_rows'] = $this->sms_credit_model->get_packages()->num_rows();
 		$config['per_page'] = $this->Kalkun_model->get_setting()->row('paging');
 		$config['cur_tag_open'] = '<span id="current">';
 		$config['cur_tag_close'] = '</span>';
@@ -138,11 +138,11 @@ class Sms_credit extends Plugin_controller {
 		if ($_POST)
 		{
 			$data['query'] = $this->input->post('query');
-			$data['packages'] = $this->plugin_model->search_packages($data['query']);
+			$data['packages'] = $this->sms_credit_model->search_packages($data['query']);
 		}
 		else
 		{
-			$data['packages'] = $this->plugin_model->get_packages($param);
+			$data['packages'] = $this->sms_credit_model->get_packages($param);
 		}
 
 		$data['main'] = 'packages';
@@ -172,7 +172,7 @@ class Sms_credit extends Plugin_controller {
 
 			$param['template_name'] = trim($this->input->post('package_name'));
 			$param['sms_numbers'] = trim($this->input->post('sms_amount'));
-			$this->plugin_model->add_packages($param);
+			$this->sms_credit_model->add_packages($param);
 			redirect('plugin/sms_credit/packages');
 		}
 	}
@@ -188,7 +188,7 @@ class Sms_credit extends Plugin_controller {
 	 */
 	function delete_packages($id = NULL)
 	{
-		$this->plugin_model->delete_packages($id);
+		$this->sms_credit_model->delete_packages($id);
 		redirect('plugin/sms_credit/packages');
 	}
 }

--- a/application/plugins/sms_credit/sms_credit.php
+++ b/application/plugins/sms_credit/sms_credit.php
@@ -74,13 +74,13 @@ function sms_credit($sms)
 {
 	$CI = &get_instance();
 	$CI->load->model('Kalkun_model');
-	$CI->load->model('sms_credit/sms_credit_model', 'plugin_model');
+	$CI->load->model('sms_credit/sms_credit_model', 'sms_credit_model');
 
 	$config = sms_credit_initialize();
 	$uid = $sms['uid'];
 
 	// check user credit
-	$user_package = $CI->plugin_model->get_users(array('id' => $uid, 'valid_start' => date('Y-m-d H:i:s'), 'valid_end' => date('Y-m-d H:i:s')))->row_array();
+	$user_package = $CI->sms_credit_model->get_users(array('id' => $uid, 'valid_start' => date('Y-m-d H:i:s'), 'valid_end' => date('Y-m-d H:i:s')))->row_array();
 
 	if (isset($user_package['sms_numbers']))
 	{

--- a/application/plugins/sms_member/controllers/Sms_member.php
+++ b/application/plugins/sms_member/controllers/Sms_member.php
@@ -30,7 +30,7 @@ class Sms_member extends Plugin_controller {
 	function __construct()
 	{
 		parent::__construct();
-		$this->load->model('sms_member_model', 'plugin_model');
+		$this->load->model('sms_member_model');
 	}
 
 	// --------------------------------------------------------------------
@@ -46,8 +46,8 @@ class Sms_member extends Plugin_controller {
 	{
 		$data['main'] = 'index';
 		$data['title'] = 'SMS Member';
-		$data['total_member'] = $this->plugin_model->get_member('total')->row('count');
-		$data['member'] = $this->plugin_model->get_member('all')->result_array();
+		$data['total_member'] = $this->sms_member_model->get_member('total')->row('count');
+		$data['member'] = $this->sms_member_model->get_member('all')->result_array();
 
 		$this->load->view('main/layout', $data);
 	}

--- a/application/plugins/sms_member/sms_member.php
+++ b/application/plugins/sms_member/sms_member.php
@@ -102,12 +102,12 @@ function sms_member($sms)
 function register_member($number)
 {
 	$CI = &get_instance();
-	$CI->load->model('sms_member/sms_member_model', 'plugin_model');
+	$CI->load->model('sms_member/sms_member_model', 'sms_member_model');
 
 	//check if number not registered
-	if ($CI->plugin_model->check_member($number) === 0)
+	if ($CI->sms_member_model->check_member($number) === 0)
 	{
-		$CI->plugin_model->add_member($number);
+		$CI->sms_member_model->add_member($number);
 	}
 }
 
@@ -121,11 +121,11 @@ function register_member($number)
 function unregister_member($number)
 {
 	$CI = &get_instance();
-	$CI->load->model('sms_member/sms_member_model', 'plugin_model');
+	$CI->load->model('sms_member/sms_member_model', 'sms_member_model');
 
 	//check if already registered
-	if ($CI->plugin_model->check_member($number) === 1)
+	if ($CI->sms_member_model->check_member($number) === 1)
 	{
-		$CI->plugin_model->remove_member($number);
+		$CI->sms_member_model->remove_member($number);
 	}
 }

--- a/application/plugins/sms_to_email/controllers/Sms_to_email.php
+++ b/application/plugins/sms_to_email/controllers/Sms_to_email.php
@@ -25,7 +25,7 @@ class Sms_to_email extends Plugin_controller {
 	function __construct()
 	{
 		parent::__construct();
-		$this->load->model('sms_to_email_model', 'plugin_model');
+		$this->load->model('sms_to_email_model');
 	}
 
 	function index()
@@ -33,7 +33,7 @@ class Sms_to_email extends Plugin_controller {
 		$this->load->helper('form');
 		$data['title'] = 'SMS to Email Settings';
 		$data['main'] = 'index';
-		$data['settings'] = $this->plugin_model->get_setting($this->session->userdata('id_user'));
+		$data['settings'] = $this->sms_to_email_model->get_setting($this->session->userdata('id_user'));
 		if ($data['settings']->num_rows() === 1)
 		{
 			$data['mode'] = 'edit';
@@ -49,7 +49,7 @@ class Sms_to_email extends Plugin_controller {
 	{
 		if ($_POST)
 		{
-			$this->plugin_model->save_setting();
+			$this->sms_to_email_model->save_setting();
 			redirect('plugin/sms_to_email');
 		}
 	}

--- a/application/plugins/sms_to_email/sms_to_email.php
+++ b/application/plugins/sms_to_email/sms_to_email.php
@@ -80,7 +80,7 @@ function sms_to_email($sms)
 	$CI = &get_instance();
 	$CI->load->library('email');
 	$CI->load->model('Phonebook_model');
-	$CI->load->model('sms_to_email/sms_to_email_model', 'plugin_model');
+	$CI->load->model('sms_to_email/sms_to_email_model', 'sms_to_email_model');
 
 	if ( ! is_array($sms->msg_user))
 	{
@@ -90,7 +90,7 @@ function sms_to_email($sms)
 
 	foreach ($msg_user as $uid)
 	{
-		$active = $CI->plugin_model->get_setting($uid);
+		$active = $CI->sms_to_email_model->get_setting($uid);
 		if ($active->num_rows() === 0 OR $active->row('email_forward') !== 'true')
 		{
 			continue;

--- a/application/plugins/sms_to_twitter/controllers/Sms_to_twitter.php
+++ b/application/plugins/sms_to_twitter/controllers/Sms_to_twitter.php
@@ -25,21 +25,21 @@ class Sms_to_twitter extends Plugin_controller {
 	function __construct()
 	{
 		parent::__construct();
-		$this->load->model('sms_to_twitter_model', 'plugin_model');
+		$this->load->model('sms_to_twitter_model');
 	}
 
 	function index()
 	{
 		$data['title'] = 'Twitter Connect Status';
 		$data['main'] = 'index';
-		$data['status'] = $this->plugin_model->check_token($this->session->userdata('id_user'));
+		$data['status'] = $this->sms_to_twitter_model->check_token($this->session->userdata('id_user'));
 		$this->load->view('main/layout', $data);
 	}
 
 	function connect()
 	{
 		// Database check
-		if ($this->plugin_model->check_token($this->session->userdata('id_user')))
+		if ($this->sms_to_twitter_model->check_token($this->session->userdata('id_user')))
 		{
 			$this->session->set_flashdata('notif', 'Already connected to Twitter');
 			redirect('sms_to_twitter');
@@ -70,14 +70,14 @@ class Sms_to_twitter extends Plugin_controller {
 			$param['id_user'] = $this->session->userdata('id_user');
 			$param['access_token'] = $auth['access_token'];
 			$param['access_token_secret'] = $auth['access_token_secret'];
-			$this->plugin_model->save_token($param);
+			$this->sms_to_twitter_model->save_token($param);
 			redirect('sms_to_twitter');
 		}
 	}
 
 	function disconnect()
 	{
-		$this->plugin_model->delete_token($this->session->userdata('id_user'));
+		$this->sms_to_twitter_model->delete_token($this->session->userdata('id_user'));
 		redirect('sms_to_twitter');
 	}
 }

--- a/application/plugins/sms_to_twitter/sms_to_twitter.php
+++ b/application/plugins/sms_to_twitter/sms_to_twitter.php
@@ -82,11 +82,11 @@ function sms_to_twitter($sms)
 	if (strtoupper($code) === strtoupper($twitter_code))
 	{
 		$CI = &get_instance();
-		$CI->load->model('sms_to_twitter/sms_to_twitter_model', 'plugin_model');
+		$CI->load->model('sms_to_twitter/sms_to_twitter_model', 'sms_to_twitter_model');
 		$CI->load->library('sms_to_twitter/twitter', 'twitter');
 
 		// if token exist
-		$tokens = $CI->plugin_model->get_token_by_phone($number);
+		$tokens = $CI->sms_to_twitter_model->get_token_by_phone($number);
 		if (is_array($tokens))
 		{
 			// Kalkun Twitter keys (DO NOT CHANGE)

--- a/application/plugins/sms_to_wordpress/controllers/Sms_to_wordpress.php
+++ b/application/plugins/sms_to_wordpress/controllers/Sms_to_wordpress.php
@@ -25,15 +25,15 @@ class Sms_to_wordpress extends Plugin_controller {
 	function __construct()
 	{
 		parent::__construct();
-		$this->load->model('sms_to_wordpress_model', 'plugin_model');
+		$this->load->model('sms_to_wordpress_model');
 	}
 	
 	function index()
 	{
 		$data['title'] = 'Wordpress Blog Status';
 		$data['main'] = 'index';
-		$data['status'] = $this->plugin_model->check_status($this->session->userdata('id_user'));
-		$data['wp'] = $this->plugin_model->get_wp($this->session->userdata('id_user'));
+		$data['status'] = $this->sms_to_wordpress_model->check_status($this->session->userdata('id_user'));
+		$data['wp'] = $this->sms_to_wordpress_model->get_wp($this->session->userdata('id_user'));
 		$this->load->view('main/layout', $data);
 	}
 	
@@ -41,14 +41,14 @@ class Sms_to_wordpress extends Plugin_controller {
 	{
 		if ($_POST)
 		{
-			$this->plugin_model->save_wp();
+			$this->sms_to_wordpress_model->save_wp();
 			redirect('sms_to_wordpress');
 		}
 	}
 	
 	function delete()
 	{
-		$this->plugin_model->delete_wp($this->session->userdata('id_user'));
+		$this->sms_to_wordpress_model->delete_wp($this->session->userdata('id_user'));
 		redirect('sms_to_wordpress');	
 	}
 }

--- a/application/plugins/sms_to_wordpress/sms_to_wordpress.php
+++ b/application/plugins/sms_to_wordpress/sms_to_wordpress.php
@@ -83,10 +83,10 @@ function sms_to_wordpress($sms)
 	if (strtoupper($code)===strtoupper($wordpress_code))
 	{
 		$CI =& get_instance();
-		$CI->load->model('sms_to_wordpress/sms_to_wordpress_model', 'plugin_model');
+		$CI->load->model('sms_to_wordpress/sms_to_wordpress_model', 'sms_to_wordpress_model');
 
 		// if wp url exist
-		$wp = $CI->plugin_model->get_wp_url_by_phone($number);
+		$wp = $CI->sms_to_wordpress_model->get_wp_url_by_phone($number);
 		if (is_array($wp))
 		{
 			$client = new IXR\Client\Client($wp['wp_url']);

--- a/application/plugins/sms_to_xmpp/controllers/Sms_to_xmpp.php
+++ b/application/plugins/sms_to_xmpp/controllers/Sms_to_xmpp.php
@@ -25,15 +25,15 @@ class Sms_to_xmpp extends Plugin_controller {
 	function __construct()
 	{
 		parent::__construct();
-		$this->load->model('sms_to_xmpp_model', 'plugin_model');
+		$this->load->model('sms_to_xmpp_model');
 	}
 
 	function index()
 	{
 		$data['title'] = 'XMPP Account Status';
 		$data['main'] = 'index';
-		$data['status'] = $this->plugin_model->check_status($this->session->userdata('id_user'));
-		$data['xmpp'] = $this->plugin_model->get_xmpp($this->session->userdata('id_user'));
+		$data['status'] = $this->sms_to_xmpp_model->check_status($this->session->userdata('id_user'));
+		$data['xmpp'] = $this->sms_to_xmpp_model->get_xmpp($this->session->userdata('id_user'));
 		$this->load->view('main/layout', $data);
 	}
 
@@ -41,14 +41,14 @@ class Sms_to_xmpp extends Plugin_controller {
 	{
 		if ($_POST)
 		{
-			$this->plugin_model->save_xmpp();
+			$this->sms_to_xmpp_model->save_xmpp();
 			redirect('sms_to_xmpp');
 		}
 	}
 
 	function delete()
 	{
-		$this->plugin_model->delete_xmpp($this->session->userdata('id_user'));
+		$this->sms_to_xmpp_model->delete_xmpp($this->session->userdata('id_user'));
 		redirect('sms_to_xmpp');
 	}
 }

--- a/application/plugins/sms_to_xmpp/sms_to_xmpp.php
+++ b/application/plugins/sms_to_xmpp/sms_to_xmpp.php
@@ -82,10 +82,10 @@ function sms_to_xmpp($sms)
 	if (strtoupper($code) === strtoupper($xmpp_code))
 	{
 		$CI = &get_instance();
-		$CI->load->model('sms_to_xmpp/sms_to_xmpp_model', 'plugin_model');
+		$CI->load->model('sms_to_xmpp/sms_to_xmpp_model');
 
 		// if xmpp account exist
-		$xmpp = $CI->plugin_model->get_xmpp_account_by_phone($number);
+		$xmpp = $CI->sms_to_xmpp_model->get_xmpp_account_by_phone($number);
 		if (is_array($xmpp))
 		{
 			$CI->load->library('encryption');

--- a/application/plugins/whitelist_number/controllers/Whitelist_number.php
+++ b/application/plugins/whitelist_number/controllers/Whitelist_number.php
@@ -26,7 +26,7 @@ class Whitelist_number extends Plugin_controller {
 	{
 		parent::__construct();
 		$this->load->model('Kalkun_model');
-		$this->load->model('whitelist_number_model', 'plugin_model');
+		$this->load->model('whitelist_number_model');
 	}
 
 	function index()
@@ -35,18 +35,18 @@ class Whitelist_number extends Plugin_controller {
 		{
 			if ($this->input->post('editid_whitelist'))
 			{
-				$this->plugin_model->update();
+				$this->whitelist_number_model->update();
 			}
 			else
 			{
-				$this->plugin_model->add();
+				$this->whitelist_number_model->add();
 			}
 			redirect('plugin/whitelist_number');
 		}
 
 		$this->load->library('pagination');
 		$config['base_url'] = site_url('plugin/whitelist_number');
-		$config['total_rows'] = $this->plugin_model->get('count');
+		$config['total_rows'] = $this->whitelist_number_model->get('count');
 		$config['per_page'] = $this->Kalkun_model->get_setting()->row('paging');
 		$config['cur_tag_open'] = '<span id="current">';
 		$config['cur_tag_close'] = '</span>';
@@ -54,14 +54,14 @@ class Whitelist_number extends Plugin_controller {
 		$this->pagination->initialize($config);
 
 		$data['main'] = 'index';
-		$data['whitelist'] = $this->plugin_model->get('paginate', $config['per_page'], $this->uri->segment(3, 0));
+		$data['whitelist'] = $this->whitelist_number_model->get('paginate', $config['per_page'], $this->uri->segment(3, 0));
 		$data['number'] = $this->uri->segment(3, 0) + 1;
 		$this->load->view('main/layout', $data);
 	}
 
 	function delete($id)
 	{
-		$this->plugin_model->delete($id);
+		$this->whitelist_number_model->delete($id);
 		redirect('plugin/whitelist_number');
 	}
 }

--- a/application/plugins/whitelist_number/whitelist_number.php
+++ b/application/plugins/whitelist_number/whitelist_number.php
@@ -54,11 +54,11 @@ function whitelist_number_install()
 function whitelist_number_outgoing($numbers = array())
 {
 	$CI = &get_instance();
-	$CI->load->model('whitelist_number/whitelist_number_model', 'plugin_model');
+	$CI->load->model('whitelist_number/whitelist_number_model', 'whitelist_number_model');
 	$heaven = array();
 
 	// Get whitelist number
-	$lists = $CI->plugin_model->get('all')->result_array();
+	$lists = $CI->whitelist_number_model->get('all')->result_array();
 	foreach ($lists as $tmp)
 	{
 		$heaven[] = $tmp['match'];


### PR DESCRIPTION
Having multiple plugins enabled led to problems because the loaded plugin_model
got overlapped by the other enabled plugins which shared the same name.