### PR TITLE
stop_manager: fix autoreply error

### DIFF
--- a/application/plugins/stop_manager/stop_manager.php
+++ b/application/plugins/stop_manager/stop_manager.php
@@ -279,6 +279,7 @@ function autoreply($tel, $reply_msg)
 {
 	$config = stop_manager_initialize();
 
+	$ret = NULL;
 	// Filter rule for outgoing SMS
 	if ($config['enable_autoreply_outnumber_filter'])
 	{
@@ -286,7 +287,7 @@ function autoreply($tel, $reply_msg)
 		//var_dump($ret);
 		//var_dump($matches);
 	}
-	if ($ret)
+	if ( ! $config['enable_autoreply_outnumber_filter'] || $ret === 1)
 	{
 		$CI = &get_instance();
 		$CI->load->model('Message_model');


### PR DESCRIPTION
there was a var not defined error, and condition to trigger was buggy