### PR TITLE
phonebook_lookup: fix php/ci error

### DIFF
--- a/application/plugins/phonebook_lookup/phonebook_lookup.php
+++ b/application/plugins/phonebook_lookup/phonebook_lookup.php
@@ -15,6 +15,7 @@ function phonebook_lookup_initialize()
 
 	$CI->load->add_package_path(APPPATH.'plugins/phonebook_lookup', FALSE);
 	$CI->load->config('phonebook_lookup', TRUE);
+	$CI->load->remove_package_path(APPPATH.'plugins/phonebook_lookup');
 
 	return $CI->config->config['phonebook_lookup'];
 }


### PR DESCRIPTION
When phonebook_lookup was enabled, going to phonebook in the UI led to php/ci errors
The views or language files weren't found. This was because of the add_package_path for the plugin.
Fix is to remove the package_path once we don't need it anymore