### PR TITLE
plugins: minor fixes

### DIFF
--- a/application/plugins/blacklist_number/controllers/Blacklist_number.php
+++ b/application/plugins/blacklist_number/controllers/Blacklist_number.php
@@ -25,7 +25,6 @@ class Blacklist_number extends Plugin_controller {
 	function __construct()
 	{
 		parent::__construct();
-		$this->load->model('Kalkun_model');
 		$this->load->model('blacklist_number_model');
 		$this->load->helper('kalkun');
 	}

--- a/application/plugins/server_alert/controllers/Server_alert.php
+++ b/application/plugins/server_alert/controllers/Server_alert.php
@@ -25,7 +25,6 @@ class Server_alert extends Plugin_controller {
 	function __construct()
 	{
 		parent::__construct();
-		$this->load->model('Kalkun_model');
 		$this->load->model('server_alert_model');
 		$this->load->helper('kalkun');
 	}

--- a/application/plugins/soap/controllers/Soap.php
+++ b/application/plugins/soap/controllers/Soap.php
@@ -25,8 +25,7 @@ class Soap extends Plugin_controller {
 	function __construct()
 	{
 		parent::__construct();
-		$this->load->model('Kalkun_model');
-		$this->load->model('soap_model', 'Plugin_model');
+		$this->load->model('soap_model');
 	}
 
 	function index()
@@ -35,7 +34,7 @@ class Soap extends Plugin_controller {
 		{
 			if ($this->input->post('editid_remote_access'))
 			{
-				$this->Plugin_model->updateRemoteAccess();
+				$this->soap_model->updateRemoteAccess();
 			}
 			else
 			{
@@ -45,7 +44,7 @@ class Soap extends Plugin_controller {
 				}
 				else
 				{
-					$this->Plugin_model->addRemoteAccess();
+					$this->soap_model->addRemoteAccess();
 				}
 			}
 			redirect('plugin/soap');
@@ -53,7 +52,7 @@ class Soap extends Plugin_controller {
 
 		$this->load->library('pagination');
 		$config['base_url'] = site_url().'/plugin/soap';
-		$config['total_rows'] = $this->Plugin_model->getRemoteAccess('count');
+		$config['total_rows'] = $this->soap_model->getRemoteAccess('count');
 		$config['per_page'] = 10;
 		//$config['per_page'] = $this->Kalkun_model->getSetting('paging', 'value')->row('value');
 		$config['cur_tag_open'] = '<span id="current">';
@@ -63,7 +62,7 @@ class Soap extends Plugin_controller {
 		$this->pagination->initialize($config);
 
 		$data['main'] = 'index';
-		$data['remote_access'] = $this->Plugin_model->getRemoteAccess('paginate', $config['per_page'], $this->uri->segment(3, 0));
+		$data['remote_access'] = $this->soap_model->getRemoteAccess('paginate', $config['per_page'], $this->uri->segment(3, 0));
 		//TODO - GET NOTIFICATION
 		$data['notification'] = array();
 		$data['number'] = $this->uri->segment(3, 0) + 1;
@@ -72,7 +71,7 @@ class Soap extends Plugin_controller {
 
 	function delete_remote_access($id)
 	{
-		$this->Plugin_model->delRemoteAccess($id);
+		$this->soap_model->delRemoteAccess($id);
 		redirect('plugin/soap');
 	}
 

--- a/application/plugins/whitelist_number/controllers/Whitelist_number.php
+++ b/application/plugins/whitelist_number/controllers/Whitelist_number.php
@@ -25,7 +25,6 @@ class Whitelist_number extends Plugin_controller {
 	function __construct()
 	{
 		parent::__construct();
-		$this->load->model('Kalkun_model');
 		$this->load->model('whitelist_number_model');
 	}
 


### PR DESCRIPTION
Remove duplicate call to ->load->model('Kalkun_model')
use real name in soap plugin for load->model('soap_model')