### PR TITLE
Improve error management & notifications

### DIFF
--- a/application/controllers/Kalkun.php
+++ b/application/controllers/Kalkun.php
@@ -188,16 +188,19 @@ class Kalkun extends MY_Controller {
 	 */
 	function unread_count()
 	{
-		$tmp_unread = $this->Message_model->get_messages(array('readed' => FALSE, 'uid' => $this->session->userdata('id_user')))->num_rows();
-		$in = ($tmp_unread > 0) ? '('.$tmp_unread.')' : '';
+		$unread_count['in'] = $this->Message_model->get_messages([
+			'readed' => FALSE,
+			'uid' => $this->session->userdata('id_user'),
+		])->num_rows();
+		$unread_count['draft'] = 0;
+		$unread_count['spam'] = $this->Message_model->get_messages([
+			'readed' => FALSE,
+			'id_folder' => '6',
+			'uid' => $this->session->userdata('id_user'),
+		])->num_rows();
 
-		$tmp_unread = 0;
-		$draft = ($tmp_unread > 0) ? '('.$tmp_unread.')' : '';
-
-		$tmp_unread = $this->Message_model->get_messages(array('readed' => FALSE, 'id_folder' => '6', 'uid' => $this->session->userdata('id_user')))->num_rows();
-		$spam = ($tmp_unread > 0) ? '('.$tmp_unread.')' : '';
-
-		echo $in. '/' . $draft . '/' . $spam;
+		header('Content-type: application/json');
+		echo json_encode($unread_count);
 	}
 
 	// --------------------------------------------------------------------

--- a/application/controllers/Messages.php
+++ b/application/controllers/Messages.php
@@ -489,17 +489,9 @@ class Messages extends MY_Controller {
 			$return_msg['msg'] = tr('No number found. SMS not sent.');
 		}
 
-		// Display sending status
-		switch ($return_msg['type'])
-		{
-			case 'error':
-				echo '<div class="notif" style="color:red">'.$return_msg['msg'].'</div>';
-				break;
-			case 'info':
-			default:
-				echo '<div class="notif">'.$return_msg['msg'].'</div>';
-				break;
-		}
+		// Return sending status
+		header('Content-type: application/json');
+		echo json_encode($return_msg);
 
 		if ($this->input->post('redirect_to_form_result') === '1')
 		{

--- a/application/controllers/Phonebook.php
+++ b/application/controllers/Phonebook.php
@@ -369,15 +369,24 @@ class Phonebook extends MY_Controller {
 		if ($this->input->post('editid_pbk'))
 		{
 			$pbk['id_pbk'] = $this->input->post('editid_pbk');
-			$msg = '<div class="notif">'.tr('Contact updated successfully.').'</div>';
+			$return_msg = [
+				'type' => 'info',
+				'msg' => tr('Contact updated successfully.'),
+			];
 		}
 		else
 		{
-			$msg = '<div class="notif">'.tr('Contact added successfully.').'</div>';
+			$return_msg = [
+				'type' => 'info',
+				'msg' => tr('Contact added successfully.'),
+			];
 		}
 
 		$this->Phonebook_model->add_contact($pbk);
-		echo $msg;
+
+		// Return status
+		header('Content-type: application/json');
+		echo json_encode($return_msg);
 	}
 
 	// --------------------------------------------------------------------

--- a/application/controllers/Users.php
+++ b/application/controllers/Users.php
@@ -119,14 +119,25 @@ class Users extends MY_Controller {
 	{
 		$this->load->helper('kalkun');
 		$this->User_model->adduser();
+
 		if ($this->input->post('id_user'))
 		{
-			echo '<div class="notif">'.tr('User updated successfully.').'</div>';
+			$return_msg = [
+				'type' => 'info',
+				'msg' => tr('User updated successfully.'),
+			];
 		}
 		else
 		{
-			echo '<div class="notif">'.tr('User added successfully.').'</div>';
+			$return_msg = [
+				'type' => 'info',
+				'msg' => tr('User added successfully.'),
+			];
 		}
+
+		// Return status
+		header('Content-type: application/json');
+		echo json_encode($return_msg);
 	}
 
 	// --------------------------------------------------------------------

--- a/application/models/gateway/Gammu_model.php
+++ b/application/models/gateway/Gammu_model.php
@@ -61,7 +61,7 @@ class Gammu_model extends MY_Model {
 					'Command: '.$cmd."\n".
 					'Output: '.implode("\n", $output)."\n".
 					'Result code: '.$result_code
-					);
+				);
 				show_error(tr('Failure to inject message into Gammu with gammu-smsd-inject. See kalkun logs.'), 500);
 
 				$f_ret = array('status' => tr('Failure to inject message into Gammu with gammu-smsd-inject. See kalkun logs.')); //FIXME

--- a/application/models/gateway/Gammu_model.php
+++ b/application/models/gateway/Gammu_model.php
@@ -52,19 +52,35 @@ class Gammu_model extends MY_Model {
 				&& $data['type'] === 'waplink')
 		{
 			$cmd = '"'.$this->config->item('gammu_sms_inject').'"' .' -c ' .'"'.$this->config->item('gammu_config').'"'. ' WAPINDICATOR ' . $data['dest']. ' "'. $data['url']. '"  "'.$data['message'].'" ';
-			$ret = exec ($cmd);
-			preg_match('/with ID ([\d]+)/i', $ret, $matches);
-			$insert_id = $matches[1];
-			if (empty($insert_id))
+			$ret = exec ($cmd, $output, $result_code);
+			if ($result_code !== 0)
 			{
-				die('<div class="notif" style="color:red">'.tr('Could not send message. Make sure Gammu path is correctly set.').'</div>');
-				$f_ret = array('status' => tr('Could not send message. Make sure Gammu path is correctly set.')); //FIXME
+				log_message(
+					'error',
+					'Failure to inject message into Gammu with gammu-smsd-inject. '."\n".
+					'Command: '.$cmd."\n".
+					'Output: '.implode("\n", $output)."\n".
+					'Result code: '.$result_code
+					);
+				show_error(tr('Failure to inject message into Gammu with gammu-smsd-inject. See kalkun logs.'), 500);
+
+				$f_ret = array('status' => tr('Failure to inject message into Gammu with gammu-smsd-inject. See kalkun logs.')); //FIXME
 			}
 			else
 			{
-				$this->db->update('outbox', array('SendingDateTime' => $data['date']), "ID = ${insert_id}");
-				$this->Kalkun_model->add_sms_used($this->session->userdata('id_user'));
-				$f_ret = array('status' => tr('Message queued.'));
+				$preg_match_ret = preg_match('/with ID ([\d]+)/i', $ret, $matches);
+				$insert_id = $matches[1];
+				if (empty($insert_id))
+				{
+					show_error(tr('Unknown error while sending WAP-LINK.'), 500);
+					$f_ret = array('status' => tr('Unknown error while sending WAP-LINK.')); //FIXME
+				}
+				else
+				{
+					$this->db->update('outbox', array('SendingDateTime' => $data['date']), "ID = ${insert_id}");
+					$this->Kalkun_model->add_sms_used($this->session->userdata('id_user'));
+					$f_ret = array('status' => tr('Message queued.'));
+				}
 			}
 		}
 		else

--- a/application/models/gateway/Gammu_model.php
+++ b/application/models/gateway/Gammu_model.php
@@ -183,7 +183,7 @@ class Gammu_model extends MY_Model {
 		}
 		else
 		{
-			show_error("Parameter invalid.", 400);
+			show_error('Parameter invalid.', 400);
 		}
 	}
 

--- a/application/models/gateway/Gammu_model.php
+++ b/application/models/gateway/Gammu_model.php
@@ -183,8 +183,7 @@ class Gammu_model extends MY_Model {
 		}
 		else
 		{
-			echo 'Parameter invalid.';
-			return array('status' => 'Parameter invalid.');
+			show_error("Parameter invalid.", 400);
 		}
 	}
 

--- a/application/views/js_init/js_layout.php
+++ b/application/views/js_init/js_layout.php
@@ -160,16 +160,21 @@
 			if (repeatable) {
 				buttons["<?php echo tr_addcslashes('"', 'Send and repeat'); ?>"] = function() {
 					if ($("#composeForm").valid()) {
-						$.post("<?php echo site_url('messages/compose_process') ?>", $("#composeForm").serialize(), function(data) {
-							$("#compose_sms_container_notif_area").text()
-							if (data.type == "error") {
-								$("#compose_sms_container_notif_area").addClass("error_notif");
-							} else {
-								$("#compose_sms_container_notif_area").removeClass("error_notif");
-							}
-							$("#compose_sms_container_notif_area").text(data.msg);
-							$("#compose_sms_container_notif_area").show();
-						});
+						$.post("<?php echo site_url('messages/compose_process') ?>", $("#composeForm").serialize())
+							.done(function(data) {
+								$("#compose_sms_container_notif_area").text()
+								if (data.type == "error") {
+									$("#compose_sms_container_notif_area").addClass("error_notif");
+								} else {
+									$("#compose_sms_container_notif_area").removeClass("error_notif");
+								}
+								$("#compose_sms_container_notif_area").text(data.msg);
+								$("#compose_sms_container_notif_area").show();
+							})
+							.fail(function(data) {
+								$("#compose_sms_container_notif_area").hide();
+								display_error_container(data);
+							});
 					}
 				};
 			}

--- a/application/views/js_init/js_layout.php
+++ b/application/views/js_init/js_layout.php
@@ -161,12 +161,14 @@
 				buttons["<?php echo tr_addcslashes('"', 'Send and repeat'); ?>"] = function() {
 					if ($("#composeForm").valid()) {
 						$.post("<?php echo site_url('messages/compose_process') ?>", $("#composeForm").serialize(), function(data) {
+							$("#compose_sms_container_notif_area").text()
 							if (data.type == "error") {
-								html = '<div class="notif" style="color:red">' + data.msg + '</div>';
+								$("#compose_sms_container_notif_area").addClass("error_notif");
 							} else {
-								html = '<div class="notif">' + data.msg + '</div>';
+								$("#compose_sms_container_notif_area").removeClass("error_notif");
 							}
-							$("#compose_sms_container").append(html);
+							$("#compose_sms_container_notif_area").text(data.msg);
+							$("#compose_sms_container_notif_area").show();
 						});
 					}
 				};

--- a/application/views/js_init/js_layout.php
+++ b/application/views/js_init/js_layout.php
@@ -100,7 +100,12 @@
 	// Error container
 	function display_error_container(data) {
 		if (data.responseText !== undefined) {
-			$("#error_container").html($(data.responseText).filter('div').removeAttr("id"));
+			attr = $(data.responseText).filter('div').attr("id");
+			if (attr === "container") {
+				$("#error_container").html($(data.responseText).filter('div').removeAttr("id"));
+			} else {
+				$("#error_container").html($(data.responseText));
+			}
 		} else {
 			$("#error_container").html("<p>" + data.statusText + "</p>");
 		}

--- a/application/views/js_init/js_layout.php
+++ b/application/views/js_init/js_layout.php
@@ -170,6 +170,9 @@
 								}
 								$("#compose_sms_container_notif_area").text(data.msg);
 								$("#compose_sms_container_notif_area").show();
+								setTimeout(function() {
+									$("#compose_sms_container_notif_area").hide();
+								}, 1500);
 							})
 							.fail(function(data) {
 								$("#compose_sms_container_notif_area").hide();

--- a/application/views/js_init/message/js_compose.php
+++ b/application/views/js_init/message/js_compose.php
@@ -151,19 +151,7 @@
 					.fail(function(data) {
 						$("#personvalue_tags_tag").removeClass("processing_image");
 						onTagInputKeydownRunning = false;
-						$("#compose_sms_container_error").html($(data.responseText).filter("div").removeAttr("id"));
-						$("#compose_sms_container_error").dialog({
-							closeText: "<?php echo tr_addcslashes('"', 'Close'); ?>",
-							modal: true,
-							width: 550,
-							show: "fade",
-							hide: "fade",
-							buttons: {
-								"<?php echo tr_addcslashes('"', 'Close'); ?>": function() {
-									$(this).dialog("destroy");
-								}
-							}
-						});
+						display_error_container(data);
 						return;
 					});
 				return;

--- a/application/views/js_init/message/js_conversation.php
+++ b/application/views/js_init/message/js_conversation.php
@@ -233,20 +233,14 @@
 					buttons: {
 						"<?php echo tr_addcslashes('"', 'Save'); ?>": function() {
 							//if($("#addContact").valid()) {
-							$.post("<?php echo site_url('phonebook/add_contact_process') ?>", $("#addContact").serialize(), function(data) {
-								$("#contact_container").html(data);
-								$("#contact_container").dialog({
-									closeText: "<?php echo tr_addcslashes('"', 'Close'); ?>",
-									buttons: {
-										"<?php echo tr_addcslashes('"', 'Close'); ?>": function() {
-											$(this).dialog("close");
-										}
-									}
+							$.post("<?php echo site_url('phonebook/add_contact_process') ?>", $("#addContact").serialize())
+								.done(function(data) {
+									show_notification(data.msg, data.type);
+									$("#contact_container").dialog("destroy");
+								})
+								.fail(function(data) {
+									display_error_container(data);
 								});
-								setTimeout(function() {
-									$("#contact_container").dialog('close')
-								}, 1500);
-							});
 						},
 						"<?php echo tr_addcslashes('"', 'Cancel'); ?>": function() {
 							$(this).dialog('close');

--- a/application/views/js_init/message/js_conversation.php
+++ b/application/views/js_init/message/js_conversation.php
@@ -331,28 +331,22 @@
 					"<?php echo tr_addcslashes('"', 'Continue'); ?>": function() {
 						delete_dup_status = $("#delete_dup").is(":checked");
 						$.post("<?php echo site_url('messages/compose_process') ?>", {
-							sendoption: 'sendoption3',
-							manualvalue: DestinationNumber,
-							senddateoption: 'option1',
-							class: Class,
-							validity: '-1',
-							smstype: 'normal',
-							sms_loop: '1',
-							message: TextDecoded
-						}, function(data) {
-							$("#compose_sms_container").html(data);
-							$("#compose_sms_container").dialog({
-								closeText: "<?php echo tr_addcslashes('"', 'Close'); ?>",
-								buttons: {
-									"<?php echo tr_addcslashes('"', 'Close'); ?>": function() {
-										$(this).dialog("close");
-									}
-								}
+								sendoption: 'sendoption3',
+								manualvalue: DestinationNumber,
+								senddateoption: 'option1',
+								class: Class,
+								validity: '-1',
+								smstype: 'normal',
+								sms_loop: '1',
+								message: TextDecoded
+							})
+							.done(function(data) {
+								show_notification(data.msg, data.type);
+								$("#compose_sms_container").dialog("destroy");
+							})
+							.fail(function(data) {
+								display_error_container(data);
 							});
-							setTimeout(function() {
-								$("#compose_sms_container").dialog('close')
-							}, 1500);
-						});
 
 						// Delete copy
 						if (delete_dup_status) {
@@ -403,28 +397,24 @@
 								ID = $(this).parents('div:eq(1)').children().children('input.select_message').attr('id');
 								Class = $(this).parents('div:eq(1)').children('div.message_metadata').children('span.class').text();
 								$.post("<?php echo site_url('messages/compose_process') ?>", {
-									sendoption: 'sendoption3',
-									manualvalue: DestinationNumber,
-									senddateoption: 'option1',
-									class: Class,
-									validity: '-1',
-									smstype: 'normal',
-									sms_loop: '1',
-									message: TextDecoded
-								}, function(data) {
-									$("#compose_sms_container").html(data);
-									$("#compose_sms_container").dialog({
-										closeText: "<?php echo tr_addcslashes('"', 'Close'); ?>",
-										buttons: {
-											"<?php echo tr_addcslashes('"', 'Close'); ?>": function() {
-												$(this).dialog("close");
-											}
-										}
+										sendoption: 'sendoption3',
+										manualvalue: DestinationNumber,
+										senddateoption: 'option1',
+										class: Class,
+										validity: '-1',
+										smstype: 'normal',
+										sms_loop: '1',
+										message: TextDecoded
+									})
+									.done(function(data) {
+										show_notification(data.msg, data.type);
+										$("#compose_sms_container").dialog("close");
+										return;
+									})
+									.fail(function(data) {
+										display_error_container(data);
+										return;
 									});
-									setTimeout(function() {
-										$("#compose_sms_container").dialog('close')
-									}, 1500);
-								});
 
 								// Delete copy
 								if (delete_dup_status) {

--- a/application/views/js_init/message/js_function.php
+++ b/application/views/js_init/message/js_function.php
@@ -44,24 +44,28 @@
 						async: false
 					});
 					$.post(delete_url + source, {
-						<?php if ($this->config->item('conversation_grouping')): ?>
-						type: 'conversation',
-						number: $(this).val(),
-						current_folder: current_folder
-						<?php else: ?>
-						type: 'single',
-						id: $(this).val(),
-						<?php endif; ?>
-					}, function(data) {
-						if (!data) {
-							$(message_row).slideUp("slow");
-							$(message_row).remove();
-						} else {
-							notif = data;
-						}
-					});
+							<?php if ($this->config->item('conversation_grouping')): ?>
+							type: 'conversation',
+							number: $(this).val(),
+							current_folder: current_folder
+							<?php else: ?>
+							type: 'single',
+							id: $(this).val(),
+							<?php endif; ?>
+						})
+						.done(function(data) {
+							if (!data) {
+								$(message_row).slideUp("slow");
+								$(message_row).remove();
+							} else {
+								notif = data;
+							}
+							show_notification(notif); // translate
+						})
+						.fail(function(data) {
+							display_error_container(data);
+						});
 				});
-				show_notification(notif); // translate
 			}
 		});
 

--- a/application/views/js_init/phonebook/js_phonebook.php
+++ b/application/views/js_init/phonebook/js_phonebook.php
@@ -40,20 +40,14 @@
 						buttons: {
 							"<?php echo tr_addcslashes('"', 'Save')?>": function() {
 								if ($('#addContact').valid()) {
-									$.post("<?php echo site_url('phonebook/add_contact_process') ?>", $("#addContact").serialize(), function(data) {
-										$("#contact_container").html(data);
-										$("#contact_container").dialog({
-											closeText: "<?php echo tr_addcslashes('"', 'Close'); ?>",
-											buttons: {
-												"<?php echo tr_addcslashes('"', 'Close'); ?>": function() {
-													$(this).dialog("close");
-												}
-											}
+									$.post("<?php echo site_url('phonebook/add_contact_process') ?>", $("#addContact").serialize())
+										.done(function(data) {
+											show_notification(data.msg, data.type);
+											$("#contact_container").dialog("destroy");
+										})
+										.fail(function(data) {
+											display_error_container(data);
 										});
-										setTimeout(function() {
-											$("#contact_container").dialog('close')
-										}, 1500);
-									});
 								} else {
 									return false;
 								}

--- a/application/views/js_init/users/js_users.php
+++ b/application/views/js_init/users/js_users.php
@@ -28,20 +28,15 @@
 					buttons: {
 						"<?php echo tr_addcslashes('"', 'Save');?>": function() {
 							if ($("#addUser").valid()) {
-								$.post("<?php echo site_url('users/add_user_process') ?>", $("#addUser").serialize(), function(data) {
-									$("#users_container").html(data);
-									$("#users_container").dialog({
-										closeText: "<?php echo tr_addcslashes('"', 'Close'); ?>",
-										buttons: {
-											"<?php echo tr_addcslashes('"', 'Close'); ?>": function() {
-												$(this).dialog("close");
-											}
-										}
+								$.post("<?php echo site_url('users/add_user_process') ?>", $("#addUser").serialize())
+									.done(function(data) {
+										show_notification(data.msg, data.type);
+										$("#users_container").dialog("destroy");
+									})
+									.fail(function(data) {
+										display_error_container(data);
 									});
-									setTimeout(function() {
-										$("#users_container").dialog('close')
-									}, 1500);
-								});
+
 							}
 							$("#users_list").load(window.location.href);
 						},

--- a/application/views/main/base.php
+++ b/application/views/main/base.php
@@ -280,4 +280,8 @@
 		</tr>
 	</table>
 	<?php echo form_close();?>
+
+	<!-- Add Error container Dialog -->
+	<div id="error_container" title="<?php echo tr('Error'); ?>" class="dialog">&nbsp;</div>
+
 </div>

--- a/application/views/main/layout.php
+++ b/application/views/main/layout.php
@@ -33,7 +33,6 @@ echo doctype('xhtml1-trans');?>
 			<div id="menu"><?php $this->load->view('main/menu');?></div>
 			<div id="content">
 				<div id="compose_sms_container" title="<?php echo tr('Compose SMS'); ?>" class="hidden">&nbsp;</div>
-				<div id="compose_sms_container_error" title="<?php echo tr('Error'); ?>" class="hidden">&nbsp;</div>
 				<?php $this->load->view($main);?>
 			</div>
 		</div>

--- a/application/views/main/messages/compose.php
+++ b/application/views/main/messages/compose.php
@@ -261,3 +261,4 @@ if ($this->config->item('sms_advertise'))
 	echo '*'.tr('Ads is active');
 }
 ?>
+<div id="compose_sms_container_notif_area" class="notif" style="display: none;"></div>

--- a/application/views/main/settings/setting.php
+++ b/application/views/main/settings/setting.php
@@ -21,7 +21,6 @@
 		</ul>
 	</div>
 	<div id="window_content">
-		<?php if ( ! empty($notif)): echo '<div class="notif">'.$notif.'</div>'; endif;?>
 		<?php if ($type != 'main/settings/filters'):?>
 		<?php
 echo form_open('settings/save', array('id' => 'settingsForm'));

--- a/media/css/blue.css
+++ b/media/css/blue.css
@@ -143,3 +143,7 @@ div.tagsinput span.tag {
 	color: black;
 	border: 1px solid #86c0d2;
 }
+
+.error_notif {
+	color: red;
+}


### PR DESCRIPTION
- Rename & move `#compose_sms_container_error` to `#error_container`
- For compose, add/edit user, contact: remove the additional dialog and put the notif that was there into the notification area.
- Improve notification that is displayed at the bottom of compose area in case of "send & repeat"
- Improve error report for sending of wap links (that uses gammu-smsd-inject)
- settings: remove useless line
- This replaces the html code sent by the Controller by JSON representation.
- update notification function

Result: kalkun really reports a HTTP error (like 500) to user, and GUI is able to catch/report it.

Fixes: https://github.com/kalkun-sms/Kalkun/issues/266
Fixes: https://github.com/kalkun-sms/Kalkun/issues/297