### PR TITLE
remove async option on ajax calls

### DIFF
--- a/application/views/js_init/message/js_conversation.php
+++ b/application/views/js_init/message/js_conversation.php
@@ -24,9 +24,6 @@
 					id_access = '#item_source' + $(this).val();
 					item_folder = $(id_access).val();
 					dest_url = base + item_folder;
-					$.ajaxSetup({
-						async: false
-					});
 					$.post(dest_url, {
 						type: 'single',
 						id: $(this).val(),

--- a/application/views/js_init/message/js_function.php
+++ b/application/views/js_init/message/js_function.php
@@ -40,9 +40,6 @@
 			} else {
 				$("input.select_conversation:checked").each(function() {
 					var message_row = $(this).parents('div:eq(2)');
-					$.ajaxSetup({
-						async: false
-					});
 					$.post(delete_url + source, {
 						<?php if ($this->config->item('conversation_grouping')): ?>
 						type: 'conversation',


### PR DESCRIPTION
Any idea why these were here? To avoid multiple DB calls at the same time?