### PR TITLE
defer loading of modernizr script

### DIFF
--- a/application/views/main/header.php
+++ b/application/views/main/header.php
@@ -9,7 +9,7 @@
 
 </style>
 <link type="text/css" rel="stylesheet" href="<?php echo $this->config->item('css_path');?>jquery-ui/jquery-ui.min.css" />
-<script language="javascript" src="<?php echo $this->config->item('js_path');?>modernizr.min.js"></script>
+<script defer language="javascript" src="<?php echo $this->config->item('js_path');?>modernizr.min.js"></script>
 <script language="javascript" src="<?php echo $this->config->item('js_path');?>jquery-3.6.0.min.js"></script>
 <script language="javascript" src="<?php echo $this->config->item('js_path');?>jquery-plugin/jquery.hotkeys.js"></script>
 <script language="javascript" src="<?php echo $this->config->item('js_path');?>jquery-plugin/jquery.field.min.js"></script>


### PR DESCRIPTION
In Firefox, the js console reports for `modernizr.js`

```
Layout was forced before the page was fully loaded. If stylesheets are not yet
loaded this may cause a flash of unstyled content.
```

This causes screen flickering when loading the page which disappears by adding
'defer' attribute to the script tag (and the error message as well).

@kingster, I'm not sure this is the correct way to fix this. Please confirm.