### PR TITLE
Enable CSRF Protection

### DIFF
--- a/application/config/config.php
+++ b/application/config/config.php
@@ -478,8 +478,8 @@ $config['global_xss_filtering'] = FALSE;
 | 'csrf_regenerate' = Regenerate token on every submission
 | 'csrf_exclude_uris' = Array of URIs which ignore CSRF checks
 */
-$config['csrf_protection'] = FALSE;
-$config['csrf_token_name'] = 'csrf_test_name';
+$config['csrf_protection'] = TRUE;
+$config['csrf_token_name'] = 'csrf_kalkun_tkn';
 $config['csrf_cookie_name'] = 'csrf_cookie_name';
 $config['csrf_expire'] = 7200;
 $config['csrf_regenerate'] = TRUE;

--- a/application/controllers/Kalkun.php
+++ b/application/controllers/Kalkun.php
@@ -361,4 +361,10 @@ class Kalkun extends MY_Controller {
 		}
 		echo json_encode($result);
 	}
+
+	function get_csrf_hash()
+	{
+		header('Content-type: application/json');
+		echo json_encode($this->security->get_csrf_hash());
+	}
 }

--- a/application/controllers/Phonebook.php
+++ b/application/controllers/Phonebook.php
@@ -404,9 +404,9 @@ class Phonebook extends MY_Controller {
 		$this->load->model('User_model');
 
 		$tagInputResult = [];
-		$output_format = $this->input->post('output_format');
+		$output_format = $this->input->get('output_format');
 
-		$q = $this->input->post('q');
+		$q = $this->input->get('q');
 		if (isset($q) && strlen($q) > 0)
 		{
 			$user_id = $this->session->userdata('id_user');

--- a/application/controllers/Phonebook.php
+++ b/application/controllers/Phonebook.php
@@ -323,26 +323,22 @@ class Phonebook extends MY_Controller {
 	{
 		$this->load->helper('form');
 		$data['pbkgroup'] = $this->Phonebook_model->get_phonebook(array('option' => 'group'));
-		$type = $this->input->post('type');
+		$type = $this->input->get('type');
 
-		if ($type === 'edit')
+		switch ($type)
 		{
-			$id_pbk = $this->input->post('param1');
-			$data['contact'] = $this->Phonebook_model->get_phonebook(array('option' => 'by_idpbk', 'id_pbk' => $id_pbk));
-		}
-		else
-		{
-			if ($type === 'message')
-			{
-				$data['number'] = $this->input->post('param1');
-			}
-			else
-			{
-				if ($type === 'normal')
-				{
-					$data['group_id'] = $this->input->post('param1');
-				}
-			}
+			case 'edit':
+				$id_pbk = $this->input->get('param1');
+				$data['contact'] = $this->Phonebook_model->get_phonebook(array('option' => 'by_idpbk', 'id_pbk' => $id_pbk));
+				break;
+			case 'message':
+				$data['number'] = $this->input->get('param1');
+				break;
+			case 'normal':
+				$data['group_id'] = $this->input->get('param1');
+				break;
+			default:
+				break;
 		}
 		$this->load->view('main/phonebook/contact/add_contact', $data);
 	}

--- a/application/controllers/Users.php
+++ b/application/controllers/Users.php
@@ -95,12 +95,12 @@ class Users extends MY_Controller {
 	function add_user()
 	{
 		$this->load->helper('form');
-		$type = $this->input->post('type');
+		$type = $this->input->get('type');
 		$data['tmp'] = '';
 
 		if ($type === 'edit')
 		{
-			$id_user = $this->input->post('param1');
+			$id_user = $this->input->get('param1');
 			$data['users'] = $this->User_model->getUsers(array('option' => 'by_iduser', 'id_user' => $id_user));
 		}
 		$this->load->view('main/users/add_user', $data);

--- a/application/plugins/sms_credit/views/js_users.php
+++ b/application/plugins/sms_credit/views/js_users.php
@@ -26,7 +26,7 @@
 					required: true,
 					remote: {
 						url: "<?php echo site_url('kalkun/phone_number_validation'); ?>",
-						type: "post",
+						type: "get",
 						data: {
 							phone: function() {
 								return $("#phone_number").val();

--- a/application/plugins/stop_manager/views/js_stop_manager.php
+++ b/application/plugins/stop_manager/views/js_stop_manager.php
@@ -32,7 +32,7 @@
 					required: true,
 					remote: {
 						url: "<?php echo site_url('kalkun/phone_number_validation'); ?>",
-						type: "post",
+						type: "get",
 						data: {
 							phone: function() {
 								return $("#destination_number").val();

--- a/application/views/js_init/js_layout.php
+++ b/application/views/js_init/js_layout.php
@@ -5,6 +5,9 @@
 		'uid' => $this->session->userdata('id_user'),
 	])->num_rows(); ?>;
 
+	csrf_name = "<?php echo $this->security->get_csrf_token_name(); ?>";
+	csrf_hash = "<?php echo $this->security->get_csrf_hash() ?>";
+
 	var refreshId = setInterval(function() {
 		$('.modem_status').load('<?php echo site_url('kalkun/notification')?>', function(responseText, textStatus, jqXHR) {
 			jqXHR
@@ -15,6 +18,15 @@
 		});
 		new_notification('true');
 	}, 60000);
+
+	function update_csrf_hash() {
+		$.get('<?php echo site_url('kalkun/get_csrf_hash')?>', function(data) {
+			csrf_hash = data;
+			$('input[name="' + csrf_name + '"]').each(function() {
+				$(this).val(csrf_hash);
+			});
+		});
+	}
 
 	function play_notification_sound() {
 		// Use HTMLAudioElement: https://developer.mozilla.org/en-US/docs/Web/API/HTMLAudioElement

--- a/application/views/js_init/js_layout.php
+++ b/application/views/js_init/js_layout.php
@@ -216,6 +216,8 @@
 								.fail(function(data) {
 									$("#compose_sms_container_notif_area").hide();
 									display_error_container(data);
+								}).always(function(data) {
+									update_csrf_hash();
 								});
 						}
 					};

--- a/application/views/js_init/message/js_compose.php
+++ b/application/views/js_init/message/js_compose.php
@@ -385,12 +385,20 @@
 			$('.loading_area').text("<?php echo tr_addcslashes('"', 'Saving...');?>");
 			$('.loading_area').fadeIn("slow");
 			$.post(dest_url, {
-				'name': name,
-				message: $('#message').val()
-			}, function() {
-				$('.loading_area').fadeOut("slow");
-				$("#canned_response_container").dialog('close');
-			});
+					'name': name,
+					message: $('#message').val(),
+					[csrf_name]: csrf_hash,
+				})
+				.done(function(data) {
+					$('.loading_area').fadeOut("slow");
+					$("#canned_response_container").dialog('close');
+				})
+				.fail(function(data) {
+					display_error_container(data);
+				})
+				.always(function(data) {
+					update_csrf_hash();
+				});
 		}
 	}
 
@@ -398,11 +406,19 @@
 
 		var dest_url = "<?php echo site_url();?>/messages/canned_response/get";
 		$.post(dest_url, {
-			'name': name
-		}, function(data) {
-			$('#message').val(data);
-			$("#canned_response_container").dialog('close');
-		});
+				'name': name,
+				[csrf_name]: csrf_hash,
+			})
+			.done(function(data) {
+				$('#message').val(data);
+				$("#canned_response_container").dialog('close');
+			})
+			.fail(function(data) {
+				display_error_container(data);
+			})
+			.always(function(data) {
+				update_csrf_hash();
+			});
 	}
 
 	function delete_canned_response(name) {
@@ -411,10 +427,18 @@
 		if (!c) return;
 		var dest_url = "<?php echo site_url();?>/messages/canned_response/delete";
 		$.post(dest_url, {
-			'name': name
-		}, function() {
-			update_canned_responses();
-		});
+				'name': name,
+				[csrf_name]: csrf_hash,
+			})
+			.done(function(data) {
+				update_canned_responses();
+			})
+			.fail(function(data) {
+				display_error_container(data);
+			})
+			.always(function(data) {
+				update_csrf_hash();
+			});
 	}
 
 	function update_canned_responses() {

--- a/application/views/js_init/message/js_compose.php
+++ b/application/views/js_init/message/js_compose.php
@@ -195,7 +195,7 @@
 					required: "#sendoption3:checked",
 					remote: {
 						url: "<?php echo site_url('kalkun/phone_number_validation'); ?>",
-						type: "post",
+						type: "get",
 						data: {
 							phone: function() {
 								return $("#manualvalue").val();

--- a/application/views/js_init/message/js_compose.php
+++ b/application/views/js_init/message/js_compose.php
@@ -127,7 +127,7 @@
 				// show loading animation
 				$("#personvalue_tags_tag").addClass("processing_image");
 
-				$.post("<?php echo site_url('phonebook/get_phonebook/').'/'.(isset($source) ? $source : '');?>", {
+				$.get("<?php echo site_url('phonebook/get_phonebook/').'/'.(isset($source) ? $source : '');?>", {
 						q: value,
 						output_format: "tagInput"
 					})

--- a/application/views/js_init/message/js_conversation.php
+++ b/application/views/js_init/message/js_conversation.php
@@ -226,35 +226,40 @@
 		// Add contact
 		$(document).on('click', '.add_to_pbk', function() {
 			var param1 = $(this).parents('div:eq(1)').children().children('input.item_number').val(); /* phone number */
-			$("#contact_container").load('<?php echo site_url('phonebook/add_contact')?>', {
-				'type': 'message',
-				'param1': param1
-			}, function() {
-				$(this).dialog({
-					title: "<?php echo tr_addcslashes('"', 'Add contact');?>",
-					closeText: "<?php echo tr_addcslashes('"', 'Close'); ?>",
-					modal: true,
-					show: 'fade',
-					hide: 'fade',
-					buttons: {
-						"<?php echo tr_addcslashes('"', 'Save'); ?>": function() {
-							//if($("#addContact").valid()) {
-							$.post("<?php echo site_url('phonebook/add_contact_process') ?>", $("#addContact").serialize())
-								.done(function(data) {
-									show_notification(data.msg, data.type);
-									$("#contact_container").dialog("destroy");
-								})
-								.fail(function(data) {
-									display_error_container(data);
-								});
-						},
-						"<?php echo tr_addcslashes('"', 'Cancel'); ?>": function() {
-							$(this).dialog('close');
+			$.get('<?php echo site_url('phonebook/add_contact')?>', {
+					'type': 'message',
+					'param1': param1
+				})
+				.done(function(responseText, textStatus, jqXHR) {
+					$("#contact_container").html(responseText);
+					$("#contact_container").dialog({
+						title: "<?php echo tr_addcslashes('"', 'Add contact');?>",
+						closeText: "<?php echo tr_addcslashes('"', 'Close'); ?>",
+						modal: true,
+						show: 'fade',
+						hide: 'fade',
+						buttons: {
+							"<?php echo tr_addcslashes('"', 'Save'); ?>": function() {
+								//if($("#addContact").valid()) {
+								$.post("<?php echo site_url('phonebook/add_contact_process') ?>", $("#addContact").serialize())
+									.done(function(data) {
+										show_notification(data.msg, data.type);
+										$("#contact_container").dialog("destroy");
+									})
+									.fail(function(data) {
+										display_error_container(data);
+									});
+							},
+							"<?php echo tr_addcslashes('"', 'Cancel'); ?>": function() {
+								$(this).dialog('close');
+							}
 						}
-					}
+					});
+					$("#contact_container").dialog('open');
+				})
+				.fail(function(data) {
+					display_error_container(data);
 				});
-				$("#contact_container").dialog('open');
-			});
 			return false;
 		});
 

--- a/application/views/js_init/message/js_conversation.php
+++ b/application/views/js_init/message/js_conversation.php
@@ -305,10 +305,19 @@
 						return;
 					}
 					$.post("<?php echo  site_url('messages/report_spam/spam') ?>", {
-						id_message: $(this).val()
-					}, function() {
-						$(message_row).slideUp("slow");
-					});
+							id_message: $(this).val(),
+							[csrf_name]: csrf_hash,
+						})
+						.done(function() {
+							$(message_row).slideUp("slow");
+						})
+						.fail(function(data) {
+							display_error_container(data);
+						})
+						.always(function(data) {
+							update_csrf_hash();
+						});
+
 				});
 				show_notification("<?php echo tr_addcslashes('"', 'Spam reported'); ?>")
 			}
@@ -324,11 +333,19 @@
 				$("input.select_message:checked:visible").each(function() {
 					var message_row = $(this).parents('div:eq(2)');
 					$.post("<?php echo  site_url('messages/report_spam/ham') ?>", {
-						id_message: $(this).val()
-					}, function() {
-						$(message_row).slideUp("slow");
+							id_message: $(this).val(),
+							[csrf_name]: csrf_hash,
+						})
+						.done(function() {
+							$(message_row).slideUp("slow");
 
-					});
+						})
+						.fail(function(data) {
+							display_error_container(data);
+						})
+						.always(function(data) {
+							update_csrf_hash();
+						});
 				});
 				show_notification("<?php echo tr_addcslashes('"', 'Message(s) marked non-spam'); ?>")
 			}

--- a/application/views/js_init/message/js_conversation.php
+++ b/application/views/js_init/message/js_conversation.php
@@ -28,16 +28,25 @@
 						async: false
 					});
 					$.post(dest_url, {
-						type: 'single',
-						id: $(this).val(),
-						current_folder: current_folder
-					}, function(data) {
-						if (!data) {
-							$(message_row).slideUp("slow");
-						} else {
-							notif = data;
-						}
-					});
+							type: 'single',
+							id: $(this).val(),
+							current_folder: current_folder,
+							[csrf_name]: csrf_hash,
+						})
+						.done(
+							function(data) {
+								if (!data) {
+									$(message_row).slideUp("slow");
+								} else {
+									notif = data;
+								}
+							})
+						.fail(function(data) {
+							display_error_container(data);
+						})
+						.always(function(data) {
+							update_csrf_hash();
+						});
 				});
 				show_notification(notif);
 			}

--- a/application/views/js_init/message/js_conversation.php
+++ b/application/views/js_init/message/js_conversation.php
@@ -390,7 +390,8 @@
 										validity: '-1',
 										smstype: 'normal',
 										sms_loop: '1',
-										message: TextDecoded
+										message: TextDecoded,
+										[csrf_name]: csrf_hash,
 									})
 									.done(function(data) {
 										show_notification(data.msg, data.type);
@@ -400,16 +401,26 @@
 									.fail(function(data) {
 										display_error_container(data);
 										return;
+									})
+									.always(function(data) {
+										update_csrf_hash();
 									});
 
 								// Delete copy
 								if (delete_dup_status) {
 									dest_url = base + 'sentitems';
 									$.post(dest_url, {
-										type: 'single',
-										id: ID,
-										current_folder: current_folder
-									});
+											type: 'single',
+											id: ID,
+											current_folder: current_folder,
+											[csrf_name]: csrf_hash,
+										})
+										.fail(function(data) {
+											display_error_container(data);
+										})
+										.always(function(data) {
+											update_csrf_hash();
+										});
 								}
 							});
 						},

--- a/application/views/js_init/message/js_conversation.php
+++ b/application/views/js_init/message/js_conversation.php
@@ -68,14 +68,22 @@
 				$("input.select_message:checked:visible").each(function() {
 					var message_row = $(this).parents('div:eq(2)');
 					$.post("<?php echo  site_url('messages/move_message') ?>", {
-						type: 'single',
-						current_folder: current_folder,
-						folder: source,
-						id_folder: id_folder,
-						id_message: $(this).val()
-					}, function() {
-						$(message_row).slideUp("slow");
-					});
+							type: 'single',
+							current_folder: current_folder,
+							folder: source,
+							id_folder: id_folder,
+							id_message: $(this).val(),
+							[csrf_name]: csrf_hash,
+						})
+						.done(function() {
+							$(message_row).slideUp("slow");
+						})
+						.fail(function(data) {
+							display_error_container(data);
+						})
+						.always(function(data) {
+							update_csrf_hash();
+						});
 				});
 				var notif = "<?php echo tr_addcslashes('"', '{0} conversation(s) recovered'); ?>"
 				notif = notif.replace('{0}', count);
@@ -97,15 +105,23 @@
 					id_access = '#item_source' + $(this).val();
 					item_folder = $(id_access).val();
 					$.post("<?php echo  site_url('messages/move_message') ?>", {
-						type: 'single',
-						current_folder: current_folder,
-						folder: item_folder,
-						id_folder: id_folder,
-						id_message: $(this).val()
-					}, function() {
-						$(message_row).slideUp("slow");
-						show_notification("<?php echo tr_addcslashes('"', 'Messages moved successfully')?>")
-					});
+							type: 'single',
+							current_folder: current_folder,
+							folder: item_folder,
+							id_folder: id_folder,
+							id_message: $(this).val(),
+							[csrf_name]: csrf_hash,
+						})
+						.done(function() {
+							$(message_row).slideUp("slow");
+							show_notification("<?php echo tr_addcslashes('"', 'Messages moved successfully')?>")
+						})
+						.fail(function(data) {
+							display_error_container(data);
+						})
+						.always(function(data) {
+							update_csrf_hash();
+						});
 				});
 			}
 		});

--- a/application/views/js_init/message/js_function.php
+++ b/application/views/js_init/message/js_function.php
@@ -44,10 +44,11 @@
 						async: false
 					});
 					$.post(delete_url + source, {
+							[csrf_name]: csrf_hash,
 							<?php if ($this->config->item('conversation_grouping')): ?>
 							type: 'conversation',
 							number: $(this).val(),
-							current_folder: current_folder
+							current_folder: current_folder,
 							<?php else: ?>
 							type: 'single',
 							id: $(this).val(),
@@ -64,6 +65,9 @@
 						})
 						.fail(function(data) {
 							display_error_container(data);
+						})
+						.always(function(data) {
+							update_csrf_hash();
 						});
 				});
 			}

--- a/application/views/js_init/message/js_function.php
+++ b/application/views/js_init/message/js_function.php
@@ -89,22 +89,31 @@
 				$("input.select_conversation:checked:visible").each(function() {
 					var message_row = $(this).parents('div:eq(2)');
 					$.post(move_url, {
-						<?php if ($this->config->item('conversation_grouping')): ?>
-						type: 'conversation',
-						current_folder: current_folder,
-						folder: source,
-						id_folder: id_folder,
-						number: $(this).val()
-						<?php else: ?>
-						type: 'single',
-						current_folder: current_folder,
-						folder: source,
-						id_folder: id_folder,
-						id_message: $(this).val(),
-						<?php endif; ?>
-					}, function() {
-						$(message_row).slideUp("slow");
-					});
+							[csrf_name]: csrf_hash,
+							<?php if ($this->config->item('conversation_grouping')): ?>
+							type: 'conversation',
+							current_folder: current_folder,
+							folder: source,
+							id_folder: id_folder,
+							number: $(this).val(),
+							<?php else: ?>
+							type: 'single',
+							current_folder: current_folder,
+							folder: source,
+							id_folder: id_folder,
+							id_message: $(this).val(),
+							<?php endif; ?>
+						})
+						.done(function() {
+							$(message_row).slideUp("slow");
+						})
+						.fail(function(data) {
+							display_error_container(data);
+							return;
+						})
+						.always(function(data) {
+							update_csrf_hash();
+						});
 				});
 				show_notification(notif);
 			}
@@ -132,22 +141,31 @@
 				$("input.select_conversation:checked:visible").each(function() {
 					var message_row = $(this).parents('div:eq(2)');
 					$.post(move_url, {
-						<?php if ($this->config->item('conversation_grouping')): ?>
-						type: 'conversation',
-						current_folder: current_folder,
-						folder: source,
-						id_folder: id_folder,
-						number: $(this).val()
-						<?php else: ?>
-						type: 'single',
-						current_folder: current_folder,
-						folder: source,
-						id_folder: id_folder,
-						id_message: $(this).val(),
-						<?php endif; ?>
-					}, function() {
-						$(message_row).slideUp("slow");
-					});
+							[csrf_name]: csrf_hash,
+							<?php if ($this->config->item('conversation_grouping')): ?>
+							type: 'conversation',
+							current_folder: current_folder,
+							folder: source,
+							id_folder: id_folder,
+							number: $(this).val(),
+							<?php else: ?>
+							type: 'single',
+							current_folder: current_folder,
+							folder: source,
+							id_folder: id_folder,
+							id_message: $(this).val(),
+							<?php endif; ?>
+						})
+						.done(function() {
+							$(message_row).slideUp("slow");
+						})
+						.fail(function(data) {
+							display_error_container(data);
+							return;
+						})
+						.always(function(data) {
+							update_csrf_hash();
+						});
 				});
 				show_notification(notif);
 			}

--- a/application/views/js_init/phonebook/js_group.php
+++ b/application/views/js_init/phonebook/js_group.php
@@ -62,10 +62,18 @@
 								var row = $(this).parents('tr');
 								var id = row.attr('id');
 								$.post(dest_url, {
-									id: id
-								}, function() {
-									$(row).slideUp("slow");
-								});
+										id: id,
+										[csrf_name]: csrf_hash,
+									})
+									.done(function() {
+										$(row).slideUp("slow");
+									})
+									.fail(function(data) {
+										display_error_container(data);
+									})
+									.always(function(data) {
+										update_csrf_hash();
+									});
 							});
 							$(this).dialog('close');
 						}

--- a/application/views/js_init/phonebook/js_phonebook.php
+++ b/application/views/js_init/phonebook/js_phonebook.php
@@ -150,16 +150,24 @@
 					var row = $(this).parents('tr');
 					var id = row.attr('id');
 					$.post(dest_url, {
-						id_pbk: id,
-						id_group: grp_id
-					}, function() {
-						if (i == ($("input.select_contact:checked").length - 1)) // execute only after the last one.
-						{
-							$('.notification_area').text("<?php echo tr_addcslashes('"', 'Updated')?>");
-							$('.notification_area').show();
-							setTimeout("$('.notification_area').fadeOut();", 2000);
-						}
-					});
+							id_pbk: id,
+							id_group: grp_id,
+							[csrf_name]: csrf_hash,
+						})
+						.done(function() {
+							if (i == ($("input.select_contact:checked").length - 1)) // execute only after the last one.
+							{
+								$('.notification_area').text("<?php echo tr_addcslashes('"', 'Updated')?>");
+								$('.notification_area').show();
+								setTimeout("$('.notification_area').fadeOut();", 2000);
+							}
+						})
+						.fail(function(data) {
+							display_error_container(data);
+						})
+						.always(function(data) {
+							update_csrf_hash();
+						});
 				});
 
 			}

--- a/application/views/js_init/phonebook/js_phonebook.php
+++ b/application/views/js_init/phonebook/js_phonebook.php
@@ -108,10 +108,18 @@
 								var row = $(this).parents('tr');
 								var id = row.attr('id');
 								$.post(dest_url, {
-									id: id
-								}, function() {
-									$(row).slideUp("slow");
-								});
+										id: id,
+										[csrf_name]: csrf_hash,
+									})
+									.done(function() {
+										$(row).slideUp("slow");
+									})
+									.fail(function(data) {
+										display_error_container(data);
+									})
+									.always(function(data) {
+										update_csrf_hash();
+									});
 							});
 							$(this).dialog("close");
 						},

--- a/application/views/js_init/phonebook/js_phonebook.php
+++ b/application/views/js_init/phonebook/js_phonebook.php
@@ -24,42 +24,47 @@
 					var param1 = $(this).parents("tr:first").attr("id");
 				}
 
-				$("#contact_container").load('<?php echo site_url('phonebook/add_contact')?>', {
-					'type': type,
-					'param1': param1
-				}, function() {
-					$(this).dialog({
-						title: pbk_title,
-						closeText: "<?php echo tr_addcslashes('"', 'Close'); ?>",
-						modal: true,
-						show: 'fade',
-						hide: 'fade',
-						open: function() {
-							$("#name").trigger('focus');
-						},
-						buttons: {
-							"<?php echo tr_addcslashes('"', 'Save')?>": function() {
-								if ($('#addContact').valid()) {
-									$.post("<?php echo site_url('phonebook/add_contact_process') ?>", $("#addContact").serialize())
-										.done(function(data) {
-											show_notification(data.msg, data.type);
-											$("#contact_container").dialog("destroy");
-										})
-										.fail(function(data) {
-											display_error_container(data);
-										});
-								} else {
-									return false;
-								}
-								$("#pbk_list").load(window.location.href);
+				$.get('<?php echo site_url('phonebook/add_contact')?>', {
+						'type': type,
+						'param1': param1
+					})
+					.done(function(responseText, textStatus, jqXHR) {
+						$("#contact_container").html(responseText);
+						$("#contact_container").dialog({
+							title: pbk_title,
+							closeText: "<?php echo tr_addcslashes('"', 'Close'); ?>",
+							modal: true,
+							show: 'fade',
+							hide: 'fade',
+							open: function() {
+								$("#name").trigger('focus');
 							},
-							"<?php echo tr_addcslashes('"', 'Cancel')?>": function() {
-								$(this).dialog('close');
+							buttons: {
+								"<?php echo tr_addcslashes('"', 'Save')?>": function() {
+									if ($('#addContact').valid()) {
+										$.post("<?php echo site_url('phonebook/add_contact_process') ?>", $("#addContact").serialize())
+											.done(function(data) {
+												show_notification(data.msg, data.type);
+												$("#contact_container").dialog("destroy");
+											})
+											.fail(function(data) {
+												display_error_container(data);
+											});
+									} else {
+										return false;
+									}
+									$("#pbk_list").load(window.location.href);
+								},
+								"<?php echo tr_addcslashes('"', 'Cancel')?>": function() {
+									$(this).dialog('close');
+								}
 							}
-						}
+						});
+						$("#contact_container").dialog('open');
+					})
+					.fail(function(data) {
+						display_error_container(data);
 					});
-					$("#contact_container").dialog('open');
-				});
 			}
 			return false;
 		});

--- a/application/views/js_init/users/js_add_user.php
+++ b/application/views/js_init/users/js_add_user.php
@@ -16,7 +16,7 @@
 					required: true,
 					remote: {
 						url: "<?php echo site_url('kalkun/phone_number_validation'); ?>",
-						type: "post",
+						type: "get",
 						data: {
 							phone: function() {
 								return $("#phone_number").val();

--- a/application/views/js_init/users/js_users.php
+++ b/application/views/js_init/users/js_users.php
@@ -15,38 +15,43 @@
 				var param1 = $(this).parents("tr:first").attr("id");
 			}
 
-			$("#users_container").load("<?php echo site_url('users/add_user')?>", {
-				'type': type,
-				'param1': param1
-			}, function() {
-				$(this).dialog({
-					title: user_title,
-					closeText: "<?php echo tr_addcslashes('"', 'Close'); ?>",
-					modal: true,
-					show: 'fade',
-					hide: 'fade',
-					buttons: {
-						"<?php echo tr_addcslashes('"', 'Save');?>": function() {
-							if ($("#addUser").valid()) {
-								$.post("<?php echo site_url('users/add_user_process') ?>", $("#addUser").serialize())
-									.done(function(data) {
-										show_notification(data.msg, data.type);
-										$("#users_container").dialog("destroy");
-									})
-									.fail(function(data) {
-										display_error_container(data);
-									});
+			$.get("<?php echo site_url('users/add_user')?>", {
+					'type': type,
+					'param1': param1
+				})
+				.done(function(responseText, textStatus, jqXHR) {
+					$("#users_container").html(responseText);
+					$("#users_container").dialog({
+						title: user_title,
+						closeText: "<?php echo tr_addcslashes('"', 'Close'); ?>",
+						modal: true,
+						show: 'fade',
+						hide: 'fade',
+						buttons: {
+							"<?php echo tr_addcslashes('"', 'Save');?>": function() {
+								if ($("#addUser").valid()) {
+									$.post("<?php echo site_url('users/add_user_process') ?>", $("#addUser").serialize())
+										.done(function(data) {
+											show_notification(data.msg, data.type);
+											$("#users_container").dialog("destroy");
+										})
+										.fail(function(data) {
+											display_error_container(data);
+										});
 
+								}
+								$("#users_list").load(window.location.href);
+							},
+							"<?php echo tr_addcslashes('"', 'Cancel');?>": function() {
+								$(this).dialog('close');
 							}
-							$("#users_list").load(window.location.href);
-						},
-						"<?php echo tr_addcslashes('"', 'Cancel');?>": function() {
-							$(this).dialog('close');
 						}
-					}
+					});
+					$("#users_container").dialog('open');
+				})
+				.fail(function(data) {
+					display_error_container(data);
 				});
-				$("#users_container").dialog('open');
-			});
 			return false;
 		});
 

--- a/application/views/js_init/users/js_users.php
+++ b/application/views/js_init/users/js_users.php
@@ -102,10 +102,18 @@
 									$('.notification_area').show();
 								} else {
 									$.post(dest_url, {
-										id_user: id
-									}, function() {
-										$(row).slideUp("slow");
-									});
+											id_user: id,
+											[csrf_name]: csrf_hash,
+										})
+										.done(function() {
+											$(row).slideUp("slow");
+										})
+										.fail(function(data) {
+											display_error_container(data);
+										})
+										.always(function(data) {
+											update_csrf_hash();
+										});
 								}
 							});
 							$(this).dialog('close');

--- a/application/views/main/base.php
+++ b/application/views/main/base.php
@@ -72,11 +72,14 @@
 
 <!-- Add Folder Dialog -->
 <div id="addfolderdialog" title="<?php echo tr('Add folder');?>" class="dialog">
-	<form class="addfolderform" method="post" action="<?php echo  site_url();?>/kalkun/add_folder">
-		<label for="name"><?php echo tr('Folder name');?></label>
-		<input type="hidden" name="id_user" value="<?php echo $this->session->userdata('id_user');?>" />
-		<input type="text" name="folder_name" id="folder_name" class="text ui-widget-content ui-corner-all" />
-	</form>
+	<?php
+	$this->load->helper('form');
+	echo form_open('kalkun/add_folder', array('class' => 'addfolderform'));
+?>
+	<label for="name"><?php echo tr('Folder name');?></label>
+	<input type="hidden" name="id_user" value="<?php echo $this->session->userdata('id_user');?>" />
+	<input type="text" name="folder_name" id="folder_name" class="text ui-widget-content ui-corner-all" />
+	<?php echo form_close(); ?>
 </div>
 
 <!-- Shortcuts dialog -->

--- a/application/views/main/messages/index.php
+++ b/application/views/main/messages/index.php
@@ -33,12 +33,15 @@ if ($this->uri->segment(2) == 'my_folder')
 
 <!-- Rename Folder Dialog -->
 <div id="renamefolderdialog" title="<?php echo tr('Rename folder');?>" class="dialog">
-	<form class="renamefolderform" method="post" action="<?php echo site_url();?>/kalkun/rename_folder">
-		<label for="name"><?php echo tr('Folder name');?></label>
-		<input type="hidden" name="id_folder" value="<?php echo htmlentities($this->uri->segment(4), ENT_QUOTES);?>" />
-		<input type="hidden" name="source_url" value="<?php echo htmlentities($this->uri->uri_string(), ENT_QUOTES);?>" />
-		<input type="text" name="edit_folder_name" id="edit_folder_name" class="text ui-widget-content ui-corner-all" />
-	</form>
+	<?php
+	$this->load->helper('form');
+	echo form_open('kalkun/rename_folder', array('class' => 'renamefolderform'));
+?>
+	<label for="name"><?php echo tr('Folder name');?></label>
+	<input type="hidden" name="id_folder" value="<?php echo htmlentities($this->uri->segment(4), ENT_QUOTES);?>" />
+	<input type="hidden" name="source_url" value="<?php echo htmlentities($this->uri->uri_string(), ENT_QUOTES);?>" />
+	<input type="text" name="edit_folder_name" id="edit_folder_name" class="text ui-widget-content ui-corner-all" />
+	<?php echo form_close(); ?>
 </div>
 
 <!-- Delete Folder Confirmation -->

--- a/application/views/main/phonebook/contact/add_contact.php
+++ b/application/views/main/phonebook/contact/add_contact.php
@@ -66,7 +66,7 @@
 	jQuery.validator.classRuleSettings.phone = {
 		remote: {
 			url: "<?php echo site_url('kalkun/phone_number_validation'); ?>",
-			type: "post",
+			type: "get",
 			data: {
 				phone: function() {
 					return $("#number").val();

--- a/application/views/main/phonebook/contact/index.php
+++ b/application/views/main/phonebook/contact/index.php
@@ -24,29 +24,32 @@
 <!-- Import Phonebook dialog -->
 <div id="pbkimportdialog" title="<?php echo tr('From CSV file');?>" class="dialog">
 	<p id="validateTips"><?php echo tr('All form fields are required.'); ?></p>
-	<form class="importpbkform" method="post" enctype="multipart/form-data" action="<?php echo site_url();?>/phonebook/import_phonebook">
-		<fieldset>
-			<input type="hidden" name="pbk_id_user" id="pbk_id_user" value="<?php echo $this->session->userdata('id_user');?>" />
-			<label for="csvfile"><?php echo tr('CSV file');?></label>
-			<input type="file" name="csvfile" id="csvfile" class="text ui-widget-content ui-corner-all" />
-			<p><small><?php echo tr('The CSV file must be in valid format').':';?> <a href="<?php echo $this->config->item('csv_path');?>contact_sample.csv"><b><?php echo tr('valid example');?></b></a></small></p>
-			<p><input type="checkbox" name="is_public" id="is_public" style="display: inline" <?php if (isset($contact) && $contact->row('is_public') == 'true')
+	<?php
+	$this->load->helper('form');
+	echo form_open_multipart('phonebook/import_phonebook', array('class' => 'importpbkform'));
+?>
+	<fieldset>
+		<input type="hidden" name="pbk_id_user" id="pbk_id_user" value="<?php echo $this->session->userdata('id_user');?>" />
+		<label for="csvfile"><?php echo tr('CSV file');?></label>
+		<input type="file" name="csvfile" id="csvfile" class="text ui-widget-content ui-corner-all" />
+		<p><small><?php echo tr('The CSV file must be in valid format').':';?> <a href="<?php echo $this->config->item('csv_path');?>contact_sample.csv"><b><?php echo tr('valid example');?></b></a></small></p>
+		<p><input type="checkbox" name="is_public" id="is_public" style="display: inline" <?php if (isset($contact) && $contact->row('is_public') == 'true')
 {
 	echo 'checked="checked"';
 }?> />
-				<label for="is_public" style="display: inline"><?php echo tr('Set as public contact');?></label>
-			</p>
-			<label for="group"><?php echo tr('Groups');?></label>
-			<select id="importgroupvalue" name="importgroupvalue">
-				<option value="">-- <?php echo tr('Select group name');?> --</option>
-				<?php
+			<label for="is_public" style="display: inline"><?php echo tr('Set as public contact');?></label>
+		</p>
+		<label for="group"><?php echo tr('Groups');?></label>
+		<select id="importgroupvalue" name="importgroupvalue">
+			<option value="">-- <?php echo tr('Select group name');?> --</option>
+			<?php
 		foreach ($pbkgroup as $tmp):
 		echo '<option value="'.$tmp->ID.'">'.htmlentities($tmp->GroupName, ENT_QUOTES).'</option>';
 		endforeach;
 		?>
-			</select>
-		</fieldset>
-	</form>
+		</select>
+	</fieldset>
+	<?php echo form_close(); ?>
 </div>
 
 

--- a/application/views/main/phonebook/group/index.php
+++ b/application/views/main/phonebook/group/index.php
@@ -9,14 +9,17 @@
 
 <!-- Add/Edit Group dialog -->
 <div id="addgroupdialog" title="<?php echo tr('Create group');?>" class="dialog">
-	<form class="addgroupform" method="post" action="<?php echo  site_url();?>/phonebook/add_group">
-		<input type="hidden" name="pbkgroup_id_user" value="<?php echo $this->session->userdata('id_user');?>" />
-		<input type="hidden" name="pbkgroup_id" class="pbkgroup_id" value="" />
-		<label for="name"><?php echo tr('Group name');?></label>
-		<input type="text" name="group_name" id="group_name" class="text ui-widget-content ui-corner-all" />
-		<input type="checkbox" name="is_public" id="is_public" style="display: inline" />
-		<label for="is_public" style="display: inline"><?php echo tr('Set as public group');?></label>
-	</form>
+	<?php
+	$this->load->helper('form');
+	echo form_open('phonebook/add_group', array('class' => 'addgroupform'));
+?>
+	<input type="hidden" name="pbkgroup_id_user" value="<?php echo $this->session->userdata('id_user');?>" />
+	<input type="hidden" name="pbkgroup_id" class="pbkgroup_id" value="" />
+	<label for="name"><?php echo tr('Group name');?></label>
+	<input type="text" name="group_name" id="group_name" class="text ui-widget-content ui-corner-all" />
+	<input type="checkbox" name="is_public" id="is_public" style="display: inline" />
+	<label for="is_public" style="display: inline"><?php echo tr('Set as public group');?></label>
+	<?php echo form_close(); ?>
 </div>
 
 <div id="window_container">

--- a/application/views/main/settings/filters.php
+++ b/application/views/main/settings/filters.php
@@ -32,24 +32,27 @@
 
 <!-- Filter Dialog -->
 <div id="filterdialog" title="<?php echo tr('Filters');?>" class="dialog">
-	<form class="addfilterform" method="post" action="<?php echo site_url('settings/save');?>">
-		<input type="hidden" name="option" value="filters" />
-		<input type="hidden" name="id_filter" id="id_filter" value="" />
-		<input type="hidden" name="id_user" value="<?php echo $this->session->userdata('id_user');?>" />
+	<?php
+	$this->load->helper('form');
+	echo form_open('settings/save', array('class' => 'addfilterform'));
+?>
+	<input type="hidden" name="option" value="filters" />
+	<input type="hidden" name="id_filter" id="id_filter" value="" />
+	<input type="hidden" name="id_user" value="<?php echo $this->session->userdata('id_user');?>" />
 
-		<label for="from"><?php echo tr('From');?></label>
-		<input type="text" name="from" id="from" class="text ui-widget-content ui-corner-all" />
+	<label for="from"><?php echo tr('From');?></label>
+	<input type="text" name="from" id="from" class="text ui-widget-content ui-corner-all" />
 
-		<label for="has_the_words"><?php echo tr('Has the words');?></label>
-		<input type="text" name="has_the_words" id="has_the_words" class="text ui-widget-content ui-corner-all" />
+	<label for="has_the_words"><?php echo tr('Has the words');?></label>
+	<input type="text" name="has_the_words" id="has_the_words" class="text ui-widget-content ui-corner-all" />
 
-		<label for="move_to"><?php echo tr('Move to');?></label>
-		<select name="id_folder" id="id_folder" style="width: 98%">
-			<?php foreach ($my_folders->result() as $my_folder): ?>
-			<option value="<?php echo $my_folder->id_folder; ?>"><?php echo htmlentities($my_folder->name, ENT_QUOTES); ?></option>
-			<?php endforeach; ?>
-		</select>
-	</form>
+	<label for="move_to"><?php echo tr('Move to');?></label>
+	<select name="id_folder" id="id_folder" style="width: 98%">
+		<?php foreach ($my_folders->result() as $my_folder): ?>
+		<option value="<?php echo $my_folder->id_folder; ?>"><?php echo htmlentities($my_folder->name, ENT_QUOTES); ?></option>
+		<?php endforeach; ?>
+	</select>
+	<?php echo form_close(); ?>
 </div>
 
 <!-- Delete Filter Dialog -->


### PR DESCRIPTION
- The POST requests that don't change the state of data were converted to GET (avoids to have to refresh all the time the token when this was done through Ajax)
- Use form_open() of CI to automatically adds the hidden CSRF input field required when enabling CSRF
- Add CSRF token to POST data for the calls made by jquery
- Refresh token when when jquery made a POST for which data is built by javascript.