### PR TITLE
Allow to trigger UI action through POST

### DIFF
--- a/application/views/js_init/js_layout.php
+++ b/application/views/js_init/js_layout.php
@@ -257,23 +257,26 @@
 
 	$(document).ready(function() {
 
-		<?php switch ($this->input->get('action')):
-		case NULL:
-			break;
-		case 'compose': ?>
-		compose_message(
-			'<?php echo $this->input->get('type'); ?>',
-			true,
-			'#personvalue_tags_tag',
-			"<?php echo $this->input->get('phone'); ?>",
-			"<?php echo $this->input->get('msg'); ?>"
-		);
-		<?php break;
-		default:
-			// TODO for other actions that show a dialog (add/edit user, add/edit contact...).
-?>
-		<?php break; ?>
-		<?php endswitch; ?>
+		// Do the UI action requested by GET or POST
+		var post_get_data = JSON.parse($("#post_get_data").text());
+
+		if ("action" in post_get_data) {
+			switch (post_get_data.action) {
+				case 'compose':
+					if ("type" in post_get_data && post_get_data.type == "prefill" && "phone" in post_get_data && "msg" in post_get_data) {
+						compose_message(
+							post_get_data.type,
+							true,
+							'#manualvalue',
+							post_get_data.phone,
+							post_get_data.msg);
+					}
+					break;
+					// TODO: Support additional UI actions: add/edit user, contact
+				default:
+					break;
+			}
+		}
 
 		// Get current page for styling/css
 		$("#menu").find("a[href='" + window.location.href + "']").each(function() {

--- a/application/views/main/base.php
+++ b/application/views/main/base.php
@@ -287,4 +287,32 @@
 	<!-- Add Error container Dialog -->
 	<div id="error_container" title="<?php echo tr('Error'); ?>" class="dialog">&nbsp;</div>
 
+	<!-- POST or GET data container -->
+	<div id="post_get_data" style="display: none;">
+		<?php
+	if ($this->input->post())
+	{
+		echo htmlentities(json_protect($this->input->post(), ENT_QUOTES));
+	}
+	else
+	{
+		if ($this->session->flashdata('bef_login_post_data'))
+		{
+			echo htmlentities(json_protect($this->session->flashdata('bef_login_post_data'), ENT_QUOTES));
+		}
+		else
+		{
+			if ($this->input->get())
+			{
+				echo htmlentities(json_protect($this->input->get(), ENT_QUOTES));
+			}
+			else
+			{
+				echo htmlentities(json_protect([], ENT_QUOTES));
+			}
+		}
+	}
+
+?>
+	</div>
 </div>


### PR DESCRIPTION
Improvement of 82f56737f3ed3fea83b251aee76d3aaa3c148a67 (which made it with
GET) to support also POST.

POST can be useful for security, for eg if one doesn't want have the query
tring in the server logs or in the URL of the browser.