### PR TITLE
Store POST data in session flashdata for reuse after login

### DIFF
--- a/application/controllers/Login.php
+++ b/application/controllers/Login.php
@@ -68,6 +68,10 @@ class Login extends CI_Controller {
 	function index()
 	{
 		$this->load->helper('form');
+		$this->session->set_flashdata(
+			'bef_login_post_data',
+			$this->session->flashdata('bef_login_post_data')
+		);
 		if ($_POST && empty($this->input->post('change_language')))
 		{
 			$this->Kalkun_model->login();

--- a/application/core/MY_Controller.php
+++ b/application/core/MY_Controller.php
@@ -57,7 +57,14 @@ class MY_Controller  extends CI_Controller {
 				{
 					redirect('login?l='.$this->input->get('l'));
 				}
-				redirect('login?r_url='.urlencode(current_url().'?'.parse_url($_SERVER['REQUEST_URI'], PHP_URL_QUERY)));
+				$this->session->set_flashdata('bef_login_post_data', $this->input->post());
+
+				$request_uri_qry_string = parse_url($_SERVER['REQUEST_URI'], PHP_URL_QUERY);
+				if ( ! empty($request_uri_qry_string))
+				{
+					$request_uri_qry_string = '?'.$request_uri_qry_string;
+				}
+				redirect('login?r_url='.urlencode(current_url().$request_uri_qry_string));
 			}
 
 			$this->load->model('Kalkun_model');


### PR DESCRIPTION
If one is POSTing to a kalkun page but is no more logged in, he will be
forwared to the login screen. BTW he would lose the POST data.

This will permit to keep the POST data for use by the page that is loaded
after login.

BTW: don't put the "?" in URL if query string is empty