### PR TITLE
increase delay to set focus in compose dialog

### DIFF
--- a/application/views/js_init/js_layout.php
+++ b/application/views/js_init/js_layout.php
@@ -245,7 +245,7 @@
 							// Need to use setTimeout to be able to access focus_element in the case the focus on a tagsInput element.
 							$(focus_element).trigger('focus');
 							return;
-						}, 1);
+						}, 300);
 					}
 				});
 				$("#compose_sms_container").dialog('open');


### PR DESCRIPTION
With dff2804b6110f888ec97e6b4805483e674aeeeea, the input is not created early enough
by TagsInput to be focusable. So increase the delay before trying to set the focus
on the element