### PR TITLE
add CI3's application/logs directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 application/config/database.php
-application/logs/*.php
+/application/logs/*
+!/application/logs/index.html
+/application/cache/*
+!/application/cache/index.html
 .DS_Store
 
 /vendor/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 application/config/database.php
+application/logs/*.php
 .DS_Store
 
 /vendor/

--- a/application/cache/index.html
+++ b/application/cache/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>403 Forbidden</title>
+</head>
+<body>
+
+<p>Directory access is forbidden.</p>
+
+</body>
+</html>

--- a/application/logs/index.html
+++ b/application/logs/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>403 Forbidden</title>
+</head>
+<body>
+
+<p>Directory access is forbidden.</p>
+
+</body>
+</html>


### PR DESCRIPTION
It was missing and appeared in Ci 2.0.0.
If the file is missing, CI3 reports an error at install time
because we left the default config to an empty value for
log_path, so CI3 checks application/logs