### PR TITLE
fix validation bypass on edit

### DIFF
--- a/application/plugins/sms_credit/views/js_users.php
+++ b/application/plugins/sms_credit/views/js_users.php
@@ -31,7 +31,8 @@
 							phone: function() {
 								return $("#phone_number").val();
 							}
-						}
+						},
+						async: false, // Workaround so that form Submit on unchanged Edit doesn't submit on validation error.
 					}
 				},
 				password: {

--- a/application/plugins/stop_manager/views/js_stop_manager.php
+++ b/application/plugins/stop_manager/views/js_stop_manager.php
@@ -57,7 +57,8 @@
 							phone: function() {
 								return $("#destination_number").val();
 							},
-						}
+						},
+						async: false, // Workaround so that form Submit on unchanged Edit doesn't submit on validation error.
 					}
 				},
 			},

--- a/application/views/js_init/users/js_add_user.php
+++ b/application/views/js_init/users/js_add_user.php
@@ -21,7 +21,8 @@
 							phone: function() {
 								return $("#phone_number").val();
 							}
-						}
+						},
+						async: false, // Workaround so that form Submit on unchanged Edit doesn't submit on validation error.
 					}
 				},
 				password: {

--- a/application/views/main/phonebook/contact/add_contact.php
+++ b/application/views/main/phonebook/contact/add_contact.php
@@ -77,9 +77,10 @@
 					phone: function() {
 						return $("#number").val();
 					}
-				}
-			};
-		});
+				},
+				async: false, // Workaround so that form Submit on unchanged Edit doesn't submit on validation error.
+			},
+		};
 	});
 
 </script>


### PR DESCRIPTION
If you Edit a user or a contact that is already in the DB having a
Phone number in the DB that is not valid (as per phone_number_validation)
JQuery validation would show in the form that the field is not valid
but still submit the form with the invalid number.

Workaround is to make the "remote" call async.

Found in a comment of
https://stackoverflow.com/q/2710548/15401262