### PR TITLE
set intl phone number format when processing composed message

### DIFF
--- a/application/controllers/Messages.php
+++ b/application/controllers/Messages.php
@@ -342,11 +342,7 @@ class Messages extends MY_Controller {
 				$tmp_dest = explode(',', $this->input->post('manualvalue'));
 				foreach ($tmp_dest as $key => $tmp)
 				{
-					$tmp = trim($tmp); // remove space
-					if (trim($tmp) !== '')
-					{
-						$dest[$key] = $tmp;
-					}
+					$dest[$key] = phone_format_e164($tmp);
 				}
 				break;
 
@@ -357,11 +353,7 @@ class Messages extends MY_Controller {
 					$tmp_dest = explode(',', $this->input->post('Number'));
 					foreach ($tmp_dest as $key => $tmp)
 					{
-						$tmp = trim($tmp); // remove space
-						if (trim($tmp) !== '')
-						{
-							$dest[$key] = $tmp;
-						}
+						$dest[$key] = phone_format_e164($tmp);
 					}
 				}
 				break;


### PR DESCRIPTION
Since we use the intl phone number format with libphonenumber for storage and
internal use, we have to do it here too. Otherwise phone number comparison in plugins
fail because number don't have the same format