### PR TITLE
fix order of country codes

### DIFF
--- a/application/views/main/settings/general.php
+++ b/application/views/main/settings/general.php
@@ -21,10 +21,14 @@ foreach ($supported_regions as $region)
 {
 	$country = Locale::getDisplayRegion('-'.$region, $this->lang->locale);
 	$label = $country . ' (+' . $phoneNumberUtil->getCountryCodeForRegion($region) . ')';
-	$country_calling_codes += [$region => htmlentities($label, ENT_QUOTES)];
+	$country_calling_codes += [$region => $label];
 }
 $collator = new Collator($this->lang->locale);
 $collator->asort($country_calling_codes);
+foreach ($country_calling_codes as $region => $label)
+{
+	$country_calling_codes[$region] = htmlentities($label, ENT_QUOTES);
+}
 $dial_code_act = $this->Kalkun_model->get_setting()->row('country_code');
 echo form_dropdown('dial_code', $country_calling_codes, $dial_code_act);
 ?>


### PR DESCRIPTION
The order became incorrect after having added the html_entities.

We defer html_entities to after the sorting is done.

Bug was introduced with:

https://github.com/kalkun-sms/Kalkun/commit/fb86ca2171583502392610f6fa7628601e36c11c#diff-933b1574337e3265ad8292c60a3ca042665f512b87a45b9ea82817d9722bc8e4