### PR TITLE
cookie: set httpOnly to TRUE

### DIFF
--- a/application/config/config.php
+++ b/application/config/config.php
@@ -433,7 +433,7 @@ $config['cookie_prefix']	= '';
 $config['cookie_domain']	= '';
 $config['cookie_path']		= '/';
 $config['cookie_secure']	= FALSE;
-$config['cookie_httponly'] 	= FALSE;
+$config['cookie_httponly'] 	= TRUE;
 $config['cookie_samesite'] 	= 'Strict';
 
 /*


### PR DESCRIPTION
Actually, we don't seem to use the cookies in javascript