### PR TITLE
PHP5.6 fix: support league/csv 8.x

### DIFF
--- a/application/controllers/Messages.php
+++ b/application/controllers/Messages.php
@@ -262,10 +262,20 @@ class Messages extends MY_Controller {
 			$filePath = $_FILES['import_file']['tmp_name'];
 			//load the CSV document from a file path
 			$reader = League\Csv\Reader::createFromPath($filePath, 'r');
-			$reader->setHeaderOffset(0);
+			if (method_exists($reader, 'setHeaderOffset'))
+			{
+				// setHeaderOffset and following methods appeared with CSV League 9.x
+				$reader->setHeaderOffset(0);
 
-			$csvField = $reader->getHeader(); //returns the CSV header record
-			$csvData = $reader->getRecords(); //returns all the CSV records as an Iterator object
+				$csvField = $reader->getHeader(); //returns the CSV header record
+				$csvData = $reader->getRecords(); //returns all the CSV records as an Iterator object
+			}
+			else
+			{
+				// Case for CSV League 8.x
+				$csvField = $reader->fetchOne();
+				$csvData = $reader->fetchAssoc();
+			}
 
 			foreach ($csvData as $data)
 			{

--- a/application/controllers/Phonebook.php
+++ b/application/controllers/Phonebook.php
@@ -292,9 +292,17 @@ class Phonebook extends MY_Controller {
 
 		//load the CSV document from a file path
 		$csv = League\Csv\Reader::createFromPath($filePath, 'r');
-		$csv->setHeaderOffset(0);
-
-		$records = $csv->getRecords(); //returns all the CSV records as an Iterator object
+		if (method_exists($csv, 'setHeaderOffset'))
+		{
+			// setHeaderOffset and following methods appeared with CSV League 9.x
+			$csv->setHeaderOffset(0);
+			$records = $csv->getRecords(); //returns all the CSV records as an Iterator object
+		}
+		else
+		{
+			// Case for CSV League 8.x
+			$records = $csv->fetchAssoc();
+		}
 
 		foreach ($records as $offset => $record)
 		{


### PR DESCRIPTION
league/csv 9.x needs php >= 7.0.10
So for version below composer will install league/csv 8.x, that we need to support